### PR TITLE
style: update base 64 encoder page buttons to be more readable

### DIFF
--- a/src/components/CopyButton/index.tsx
+++ b/src/components/CopyButton/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import AssignmentTurnedIn from '@mui/icons-material/AssignmentTurnedIn';
+import ContentCopy from '@mui/icons-material/ContentCopy';
 import { Button, ButtonProps, SvgIconTypeMap } from '@mui/material';
 import { OverridableComponent } from '@mui/material/OverridableComponent';
 import * as copy from 'copy-to-clipboard';
@@ -20,7 +20,7 @@ const CopyButton: React.FC<Props> = ({
   isDisabled,
   hoverMessage,
   feedbackMessage,
-  Icon = AssignmentTurnedIn,
+  Icon = ContentCopy,
   ...otherProps
 }) => {
   const { setToasterState } = useToasterUpdate();

--- a/src/containers/Base64Encoder/index.tsx
+++ b/src/containers/Base64Encoder/index.tsx
@@ -71,8 +71,9 @@ const Base64Encoder: React.FC<Props> = ({ inputText, storeInputText }) => {
           color='primary'
           disabled={!inputText}
           onClick={() => setTransformed(services.transform(inputText, true))}
+          endIcon={<EncodeIcon />}
         >
-          <EncodeIcon />
+          Encode
         </Button>
         <Button
           variant='contained'
@@ -80,8 +81,9 @@ const Base64Encoder: React.FC<Props> = ({ inputText, storeInputText }) => {
           color='primary'
           disabled={!inputText}
           onClick={() => setTransformed(services.transform(inputText, false))}
+          endIcon={<DecodeIcon />}
         >
-          <DecodeIcon />
+          Decode
         </Button>
       </Toolbar>
 


### PR DESCRIPTION
### Description

- Updated the format of the buttons to be more similar to the rest of the site.
- Used the endIcon property instead of putting the icon inside. Also gave the encode and decode buttons text to be more -readable. Fix for #50.


### Checklist

- [ ] e2e tests completed
  - Getting a weird error on webpack compilation error, unable to get it to run on unchanged main branch. I think I still haven't fully been able to get my local setup correctly.
- [x] Added corresponding screen capture or video (recording)
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos
![image](https://github.com/user-attachments/assets/fbf0ea77-2bad-4f27-9b77-0ef0cb33f0b6)
