### PR TITLE
style: remove spellcheck from TextField

### DIFF
--- a/src/containers/CSVParser/index.tsx
+++ b/src/containers/CSVParser/index.tsx
@@ -120,6 +120,9 @@ const CSVParser: React.FC<Props> = ({ inputText, inputEncoding, inputOptions, st
             id='encoding'
             value={inputEncoding}
             autoFocus={isMdUp}
+            inputProps={{
+              spellCheck: false
+            }}
             onChange={(e) => storeInputText('lastCSVInputContentEncoding', e.target.value)}
           >
             {FILE_ENCODING_LABELS_SORTED.map((item, index) => (

--- a/src/containers/JSONConverter/index.tsx
+++ b/src/containers/JSONConverter/index.tsx
@@ -146,6 +146,9 @@ const JSONConverter: React.FC<Props> = ({
                     error={invalid}
                     type='text'
                     helperText={invalid ? 'field is required' : null}
+                    inputProps={{
+                      spellCheck: false
+                    }}
                   />
                 )}
                 control={control}
@@ -175,6 +178,9 @@ const JSONConverter: React.FC<Props> = ({
                 margin='normal'
                 error={invalid}
                 helperText={invalid ? 'field is required' : null}
+                inputProps={{
+                  spellCheck: false
+                }}
               />
             )}
             rules={{ required: true }}

--- a/src/containers/JSONFormatter/index.tsx
+++ b/src/containers/JSONFormatter/index.tsx
@@ -71,6 +71,9 @@ const JSONFormatter: React.FC<Props> = ({ inputText, storeInputText }) => {
             margin='normal'
             fullWidth={true}
             value={inputText}
+            inputProps={{
+              spellCheck: false
+            }}
             onChange={(e) => storeInputText('lastJSONFormatterValue', e.target.value)}
           />
         </div>


### PR DESCRIPTION

### Description

- Remove spellcheck from the TextField for CSVParser, JSONConverter, and JSONFormatter.
- Fix for #56.

### Checklist

- [ ] e2e tests completed
- [x] Added corresponding screen capture or video (recording)
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos
No longer have spellcheck red underline:
![image](https://github.com/user-attachments/assets/897be901-8499-4454-accd-cc382425d13e)
