### PR TITLE
feat: add json repair

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "electron-reload": "^1.5.0",
     "file-saver": "^2.0.5",
     "js-beautify": "^1.15.1",
+    "jsonrepair": "^3.11.2",
     "jwt-decode": "^4.0.0",
     "mime-db": "^1.52.0",
     "papaparse": "^5.4.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ const App: React.FC = () => {
   const About = lazy(() => import('./components/About/About'));
   const AppPreferences = lazy(() => import('./containers/AppPreferences'));
   const JSONFormatter = lazy(() => import('./containers/JSONFormatter'));
+  const JSONRepair = lazy(() => import('./containers/JSONRepair'));
   const RegExTester = lazy(() => import('./containers/RegExTester'));
   const UUIDGenerator = lazy(() => import('./containers/UUIDGenerator'));
   const JWTDecoder = lazy(() => import('./containers/JWTDecoder'));
@@ -74,6 +75,7 @@ const App: React.FC = () => {
   const featuresGroupJSON = [
     { type: JSONFormatter, path: '/JSONFormatter', label: 'JSON Format' },
     { type: JSONConverter, path: '/JSONConverter', label: 'Convert JSON' },
+    { type: JSONRepair, path: '/JSONRepair', label: 'JSON Repair' },
   ];
   const featuresGroupURL = [
     { type: URLParser, path: '/URLParser', label: 'Parser' },

--- a/src/containers/JSONRepair/index.tsx
+++ b/src/containers/JSONRepair/index.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+
+import SaveIcon from '@mui/icons-material/Save';
+import WrapTextIcon from '@mui/icons-material/WrapText';
+import { Box, Toolbar } from '@mui/material';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import { makeStyles } from '@mui/styles';
+import { connect } from 'react-redux';
+import SyntaxHighlighter from 'react-syntax-highlighter';
+import { Dispatch } from 'redux';
+
+import { SetTextInputAction, setTextAction } from '../../actions/text-actions';
+import CopyButton from '../../components/CopyButton';
+import { FeatureScreen } from '../../components/FeatureScreen/FeatureScreen';
+import { useSyntaxHighlightTheme } from '../../hooks/useSyntaxHighlightTheme';
+import { AppState } from '../../reducers';
+import * as fileService from '../../services/file-utils';
+import { useIsWidthUp } from '../../theme';
+import { jsonrepair } from 'jsonrepair';
+
+const useStyles = makeStyles((theme) => ({
+  formatted: {
+    borderColor: theme.palette.text.disabled,
+    borderStyle: 'solid',
+    borderWidth: 1,
+    borderRadius: theme.shape.borderRadius,
+    maxHeight: '500px',
+    width: '100%',
+    overflow: 'auto',
+  },
+  toolbar: {
+    margin: 0,
+    padding: 0,
+  },
+}));
+
+type Props = {
+  inputText?: string;
+  storeInputText: (name: string, value: string) => void;
+};
+
+const JSONRepair: React.FC<Props> = ({ inputText, storeInputText }) => {
+  const title = 'JSON Repair';
+  const classes = useStyles();
+  const isMdUp = useIsWidthUp('md');
+  const syntaxTheme = useSyntaxHighlightTheme();
+  const [formatted, setFormatted] = React.useState('');
+
+  React.useEffect(() => {
+    if (inputText) {
+      try {
+        setFormatted(jsonrepair(inputText));
+      } catch (e) {
+        //  do nothing user may still be typing...
+        console.error(e);
+      }
+    }
+  }, [inputText]);
+
+  const handleSaveAs = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    fileService.saveJsonAs(formatted);
+  };
+
+  return (
+    <FeatureScreen iconType={WrapTextIcon} title={title}>
+      <form noValidate autoComplete='off'>
+        <div>
+          <TextField
+            autoFocus={isMdUp}
+            label='JSON Content'
+            placeholder='Paste or type the json content here'
+            multiline={true}
+            minRows={10}
+            maxRows={isMdUp ? 20 : 10}
+            variant='outlined'
+            margin='normal'
+            fullWidth={true}
+            value={inputText}
+            inputProps={{
+              spellCheck: false
+            }}
+            onChange={(e) => storeInputText('lastJSONRepairedValue', e.target.value)}
+          />
+        </div>
+      </form>
+
+      <Toolbar className={classes.toolbar}>
+        <Box component='div' flexGrow={1}></Box>
+        <CopyButton data={formatted} sx={{ mr: 1 }} />
+        <Button
+          endIcon={<SaveIcon></SaveIcon>}
+          disabled={!formatted}
+          variant='contained'
+          color='primary'
+          onClick={handleSaveAs}
+        >
+          Save As…
+        </Button>
+      </Toolbar>
+
+      <SyntaxHighlighter style={syntaxTheme} language='json' className={classes.formatted}>
+        {formatted}
+      </SyntaxHighlighter>
+    </FeatureScreen>
+  );
+};
+
+export function mapStateToProps(state: AppState) {
+  return {
+    inputText: state.textInputs['lastJSONRepairedValue'],
+  };
+}
+
+export function mapDispatchToProps(dispatch: Dispatch<SetTextInputAction>) {
+  return {
+    storeInputText: (name: string, value: string) => dispatch(setTextAction(name, value)),
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(JSONRepair);

--- a/src/reducers/text-reducer.ts
+++ b/src/reducers/text-reducer.ts
@@ -17,6 +17,7 @@ const DEFAULT_MAP = new Map<string, string>();
 DEFAULT_MAP.set('lastUrlParserValue', 'https://codesandbox.io/dashboard/home?lastProject=WowWWW&name=Smith');
 DEFAULT_MAP.set('lastUrlEncoderValue', 'The chief export of Chuck Norris is pain.');
 DEFAULT_MAP.set('lastJSONFormatterValue', '{ "firstName": "Chuck", "lastName": "Norris" }');
+DEFAULT_MAP.set('lastJSONRepairedValue', '{\n"firstName": "Chuck",\n"lastName": "Norris",\n}'.replaceAll('"', "'"));
 DEFAULT_MAP.set(
   'lastBase64EncoderValue',
   'Chuck Norris recently had the idea to sell his pee as a canned beverage. It is now called Red Bull.'

--- a/yarn.lock
+++ b/yarn.lock
@@ -12921,6 +12921,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsonrepair@npm:^3.11.2":
+  version: 3.11.2
+  resolution: "jsonrepair@npm:3.11.2"
+  bin:
+    jsonrepair: bin/cli.js
+  checksum: 10c0/05fc70db3698aa39c73a2e4b97a2b2f875a4819fa9dd3741dd00a039f691d9e48e8ff0470af095c8c318035c9e3bcacd49771ecb173aede760f62e0f56351111
+  languageName: node
+  linkType: hard
+
 "jsprim@npm:^2.0.2":
   version: 2.0.2
   resolution: "jsprim@npm:2.0.2"
@@ -20000,6 +20009,7 @@ __metadata:
     electron-reload: "npm:^1.5.0"
     file-saver: "npm:^2.0.5"
     js-beautify: "npm:^1.15.1"
+    jsonrepair: "npm:^3.11.2"
     jwt-decode: "npm:^4.0.0"
     mime-db: "npm:^1.52.0"
     papaparse: "npm:^5.4.1"


### PR DESCRIPTION

### Description

- Add in the json repair tab under the JSON Formatter tool.
- Fix for #47.

### Checklist

- [ ] e2e tests completed
- [x] Added corresponding screen capture or video (recording)
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos
Notice the single commas around the key of `lastName` get replaced with double quotes to make valid JSON:

https://github.com/user-attachments/assets/dd075864-d541-4489-a5ad-999627fbb9a1
