### PR TITLE
feat: improve markdown anchor tag to match app theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
     "email": "amwebexpert@gmail.com",
     "url": "https://www.linkedin.com/in/amwebexpert/"
   },
+  "contributors": [
+    {
+      "name": "Anthony Buchholz",
+      "email": "anthony.buchholz@gmail.com",
+      "url": "https://yodigi7.github.io/"
+    }
+  ],
   "description": "Collection of web developer utilities",
   "homepage": ".",
   "main": "build/electron/main.js",

--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -9,11 +9,12 @@ import Typography from '@mui/material/Typography';
 import { makeStyles } from '@mui/styles';
 import { Helmet } from 'react-helmet';
 
+import { APP_VERSION_INFO } from '../../app-version-constants';
 import Banner from '../../images/icon.png';
 import AppShare from '../AppShare/AppShare';
 import AppDetail from './AppDetail';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     marginTop: 10,
   },
@@ -36,14 +37,14 @@ export default function About() {
   return (
     <>
       <Helmet title={title} />
-      <Grid container justifyContent="center" className={classes.root}>
+      <Grid container justifyContent='center' className={classes.root}>
         <Card className={classes.rootCard}>
           <CardActionArea>
-            <CardMedia className={classes.media} image={Banner} title="Web Toolbox" />
+            <CardMedia className={classes.media} image={Banner} title='Web Toolbox' />
             <CardContent>
-              <Typography variant="h5">Web Toolbox</Typography>
+              <Typography variant='h5'>Web Toolbox</Typography>
 
-              <Typography variant="subtitle2">Collection of web developer utilities</Typography>
+              <Typography variant='subtitle2'>{APP_VERSION_INFO.DESCRIPTION}</Typography>
 
               <AppShare />
 

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -6,8 +6,9 @@ import { makeStyles } from '@mui/styles';
 
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { CHANGELOG_MD } from '../../app-version-constants';
+import { APP_VERSION_INFO, CHANGELOG_MD } from '../../app-version-constants';
 import { getBuildUTCDate } from '../../services/utils';
+import { MarkdownLink } from './markdown-link';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -21,12 +22,10 @@ const Home: React.FC = () => {
 
   return (
     <Paper className={classes.root}>
-      <Alert severity='success'>
+      <Alert severity='info'>
         <AlertTitle>Last build: {getBuildUTCDate()}</AlertTitle>
 
-        <Typography variant='body1'>
-          Welcome to a collection of web developer utilities packaged as a desktop app!
-        </Typography>
+        <Typography variant='body1'>{APP_VERSION_INFO.DESCRIPTION}</Typography>
       </Alert>
 
       <TableContainer>
@@ -34,7 +33,9 @@ const Home: React.FC = () => {
           <TableBody>
             <TableRow>
               <TableCell>
-                <Markdown remarkPlugins={[remarkGfm]}>{CHANGELOG_MD}</Markdown>
+                <Markdown remarkPlugins={[remarkGfm]} components={{ a: MarkdownLink }}>
+                  {CHANGELOG_MD}
+                </Markdown>
               </TableCell>
             </TableRow>
           </TableBody>

--- a/src/components/Home/markdown-link.tsx
+++ b/src/components/Home/markdown-link.tsx
@@ -1,0 +1,10 @@
+import Link from '@mui/material/Link';
+import React, { FunctionComponent, PropsWithChildren } from 'react';
+
+interface MarkdownLinkProps extends PropsWithChildren {
+  href?: string;
+}
+
+export const MarkdownLink: FunctionComponent<MarkdownLinkProps> = ({ href, children }) => (
+  <Link href={href}>{children}</Link>
+);


### PR DESCRIPTION
### Description

- make markdown anchor style match the current app theme

### Checklist

- [ ] e2e tests completed
- [ ] Added corresponding screen capture or video (recording)
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

<img width="795" alt="image" src="https://github.com/user-attachments/assets/3748dcad-0dbd-4eec-912b-7b426bb33b3e" />
