### PR TITLE
feat: new http response code list

### DIFF
--- a/docs/assets/browser-D1auik0Y.js
+++ b/docs/assets/browser-D1auik0Y.js
@@ -1,0 +1,1 @@
+import{t as e}from"./index-D4mSplAS.js";export default e();

--- a/docs/assets/browser-lto83FQD.js
+++ b/docs/assets/browser-lto83FQD.js
@@ -1,1 +1,0 @@
-import{t as e}from"./index-DwkWiRzb.js";export default e();

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,35 +15,95 @@
 
     <!-- iOS Splash Screens -->
     <!-- iPhone 15 Pro Max, 14 Pro Max -->
-    <link rel="apple-touch-startup-image" href="logo512.png" media="(device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3)" />
+    <link
+      rel="apple-touch-startup-image"
+      href="logo512.png"
+      media="(device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3)"
+    />
     <!-- iPhone 15 Pro, 15, 14 Pro -->
-    <link rel="apple-touch-startup-image" href="logo512.png" media="(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3)" />
+    <link
+      rel="apple-touch-startup-image"
+      href="logo512.png"
+      media="(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3)"
+    />
     <!-- iPhone 14 Plus, 13 Pro Max, 12 Pro Max -->
-    <link rel="apple-touch-startup-image" href="logo512.png" media="(device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3)" />
+    <link
+      rel="apple-touch-startup-image"
+      href="logo512.png"
+      media="(device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3)"
+    />
     <!-- iPhone 14, 13, 13 Pro, 12, 12 Pro -->
-    <link rel="apple-touch-startup-image" href="logo512.png" media="(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3)" />
+    <link
+      rel="apple-touch-startup-image"
+      href="logo512.png"
+      media="(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3)"
+    />
     <!-- iPhone 13 mini, 12 mini -->
-    <link rel="apple-touch-startup-image" href="logo512.png" media="(device-width: 360px) and (device-height: 780px) and (-webkit-device-pixel-ratio: 3)" />
+    <link
+      rel="apple-touch-startup-image"
+      href="logo512.png"
+      media="(device-width: 360px) and (device-height: 780px) and (-webkit-device-pixel-ratio: 3)"
+    />
     <!-- iPhone 11 Pro Max, XS Max -->
-    <link rel="apple-touch-startup-image" href="logo512.png" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3)" />
+    <link
+      rel="apple-touch-startup-image"
+      href="logo512.png"
+      media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3)"
+    />
     <!-- iPhone 11 Pro, XS, X -->
-    <link rel="apple-touch-startup-image" href="logo512.png" media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3)" />
+    <link
+      rel="apple-touch-startup-image"
+      href="logo512.png"
+      media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3)"
+    />
     <!-- iPhone 11, XR -->
-    <link rel="apple-touch-startup-image" href="logo512.png" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2)" />
+    <link
+      rel="apple-touch-startup-image"
+      href="logo512.png"
+      media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2)"
+    />
     <!-- iPhone 8 Plus, 7 Plus, 6s Plus -->
-    <link rel="apple-touch-startup-image" href="logo512.png" media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3)" />
+    <link
+      rel="apple-touch-startup-image"
+      href="logo512.png"
+      media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3)"
+    />
     <!-- iPhone 8, 7, 6s, SE 2nd/3rd gen -->
-    <link rel="apple-touch-startup-image" href="logo512.png" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)" />
+    <link
+      rel="apple-touch-startup-image"
+      href="logo512.png"
+      media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)"
+    />
     <!-- iPhone SE 1st gen -->
-    <link rel="apple-touch-startup-image" href="logo512.png" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" />
+    <link
+      rel="apple-touch-startup-image"
+      href="logo512.png"
+      media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)"
+    />
     <!-- iPad Pro 12.9" -->
-    <link rel="apple-touch-startup-image" href="logo512.png" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)" />
+    <link
+      rel="apple-touch-startup-image"
+      href="logo512.png"
+      media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)"
+    />
     <!-- iPad Pro 11" -->
-    <link rel="apple-touch-startup-image" href="logo512.png" media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2)" />
+    <link
+      rel="apple-touch-startup-image"
+      href="logo512.png"
+      media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2)"
+    />
     <!-- iPad Pro 10.5", iPad Air -->
-    <link rel="apple-touch-startup-image" href="logo512.png" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2)" />
+    <link
+      rel="apple-touch-startup-image"
+      href="logo512.png"
+      media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2)"
+    />
     <!-- iPad Mini, iPad -->
-    <link rel="apple-touch-startup-image" href="logo512.png" media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2)" />
+    <link
+      rel="apple-touch-startup-image"
+      href="logo512.png"
+      media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2)"
+    />
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
@@ -56,7 +116,7 @@
     <link rel="icon" type="image/ico" href="favicon.ico" />
 
     <title>Web Toolbox</title>
-    <script type="module" crossorigin src="/etoolbox/assets/index-DwkWiRzb.js"></script>
+    <script type="module" crossorigin src="/etoolbox/assets/index-D4mSplAS.js"></script>
     <link rel="stylesheet" crossorigin href="/etoolbox/assets/index-3ATQF-qn.css">
   </head>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-toolbox",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "author": "amwebexpert@gmail.com",
   "repository": "https://github.com/amwebexpert/etoolbox",
   "contributors": [

--- a/src/components/layout/app-side-menu.tsx
+++ b/src/components/layout/app-side-menu.tsx
@@ -76,7 +76,7 @@ const menuItems: MenuItem[] = [
   {
     key: "/common-lists",
     icon: <UnorderedListOutlined />,
-    label: <Link to="/common-lists">Mime-types, HTML</Link>,
+    label: <Link to="/common-lists">Web References</Link>,
   },
   {
     key: "/github-user-projects",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,9 +6,9 @@ export const APP_VERSION_INFO = Object.freeze({
   DESCRIPTION: "Collection of web development utilities. Like a Swiss knife for web developers.",
   REPOSITORY: "https://github.com/amwebexpert/etoolbox",
   AUTHOR: "amwebexpert@gmail.com",
-  VERSION: "4.0.5",
+  VERSION: "4.1.0",
   VERSION_DATE: "2026-01-10",
-  VERSION_DATE_ISO: "2026-01-10T11:20:19.582Z",
+  VERSION_DATE_ISO: "2026-01-10T11:45:08.963Z",
 });
 
-export const LONG_VERSION_DATE = "4.0.5 (2026-01-10)";
+export const LONG_VERSION_DATE = "4.1.0 (2026-01-10)";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,7 @@ export const APP_VERSION_INFO = Object.freeze({
   AUTHOR: "amwebexpert@gmail.com",
   VERSION: "4.0.5",
   VERSION_DATE: "2026-01-10",
-  VERSION_DATE_ISO: "2026-01-10T10:54:42.687Z",
+  VERSION_DATE_ISO: "2026-01-10T11:20:19.582Z",
 });
 
 export const LONG_VERSION_DATE = "4.0.5 (2026-01-10)";

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -9,6 +9,7 @@ import { NamedColors } from "~/screens/colors/named/named-colors";
 import { ColorPicker } from "~/screens/colors/picker/color-picker";
 import { CommonLists } from "~/screens/common-lists/common-lists";
 import { HtmlEntities } from "~/screens/common-lists/html-entities/html-entities";
+import { HttpStatusCodes } from "~/screens/common-lists/http-status-codes/http-status-codes";
 import { MimeTypes } from "~/screens/common-lists/mime-types/mime-types";
 import { CsvParser } from "~/screens/csv-parser/csv-parser";
 import { DateConverter } from "~/screens/date-converter/date-converter";
@@ -228,6 +229,12 @@ const htmlEntitiesRoute = createRoute({
   component: HtmlEntities,
 });
 
+const httpStatusCodesRoute = createRoute({
+  getParentRoute: () => commonListsRoute,
+  path: "/http-status-codes",
+  component: HttpStatusCodes,
+});
+
 const githubUserProjectsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/github-user-projects",
@@ -278,7 +285,7 @@ const routeTree = rootRoute.addChildren([
   jwtDecoderRoute,
   qrcodeRoute.addChildren([qrcodeIndexRoute, qrcodeGeneratorRoute, qrcodeDecoderRoute]),
   imageOcrRoute,
-  commonListsRoute.addChildren([commonListsIndexRoute, mimeTypesRoute, htmlEntitiesRoute]),
+  commonListsRoute.addChildren([commonListsIndexRoute, mimeTypesRoute, htmlEntitiesRoute, httpStatusCodesRoute]),
   githubUserProjectsRoute,
   dateConverterRoute,
   csvParserRoute,

--- a/src/screens/common-lists/common-lists.tsx
+++ b/src/screens/common-lists/common-lists.tsx
@@ -3,6 +3,7 @@ import { AppLayoutTabs } from "~/components/layout/app-layout-tabs";
 const TAB_ITEMS = [
   { key: "/common-lists/mime-types", label: "Mime-types" },
   { key: "/common-lists/html-entities", label: "HTML Entities" },
+  { key: "/common-lists/http-status-codes", label: "HTTP Status Codes" },
 ];
 
 export const CommonLists = () => {

--- a/src/screens/common-lists/http-status-codes/http-status-codes-table.tsx
+++ b/src/screens/common-lists/http-status-codes/http-status-codes-table.tsx
@@ -1,0 +1,63 @@
+import { Table } from "antd";
+import { createStyles } from "antd-style";
+import { useDeferredValue } from "react";
+
+import { useResponsive } from "~/hooks/use-responsive";
+
+import { useHttpStatusCodesStore } from "./http-status-codes.store";
+import { applyFiltering, PAGE_SIZE_OPTIONS } from "./http-status-codes.utils";
+import { useHttpStatusCodesColumns } from "./use-http-status-codes-columns";
+
+export const HttpStatusCodesTable = () => {
+  const { styles } = useStyles();
+  const { isMobile } = useResponsive();
+  const columns = useHttpStatusCodesColumns();
+
+  const { category, filter, page, pageSize, setPage, setPageSize } = useHttpStatusCodesStore();
+
+  const deferredCategory = useDeferredValue(category);
+  const deferredFilter = useDeferredValue(filter);
+
+  const filteredStatusCodes = applyFiltering({ category: deferredCategory, filter: deferredFilter });
+
+  const handlePageChange = (newPage: number, newPageSize: number) => {
+    setPage(newPage);
+    if (newPageSize !== pageSize) {
+      setPageSize(newPageSize);
+    }
+  };
+
+  return (
+    <Table
+      dataSource={filteredStatusCodes}
+      columns={columns}
+      rowKey={(record) => record.code}
+      pagination={{
+        current: page,
+        pageSize: pageSize,
+        total: filteredStatusCodes.length,
+        showSizeChanger: true,
+        pageSizeOptions: PAGE_SIZE_OPTIONS.map(String),
+        showTotal: (total, range) => `${range[0]}-${range[1]} of ${total} status codes`,
+        size: isMobile ? "small" : "default",
+        onChange: handlePageChange,
+      }}
+      size="small"
+      className={styles.table}
+    />
+  );
+};
+
+const useStyles = createStyles(({ token }) => ({
+  table: {
+    ".ant-table-thead > tr > th": {
+      backgroundColor: token.colorPrimaryBg,
+    },
+    ".ant-table-tbody > tr > td": {
+      borderBottom: "none",
+      paddingBlock: 8,
+      paddingInline: 8,
+      verticalAlign: "top",
+    },
+  },
+}));

--- a/src/screens/common-lists/http-status-codes/http-status-codes-toolbar.tsx
+++ b/src/screens/common-lists/http-status-codes/http-status-codes-toolbar.tsx
@@ -1,0 +1,91 @@
+import { ClearOutlined, SearchOutlined } from "@ant-design/icons";
+import { Button, Col, Input, Row, Select, Space, Typography } from "antd";
+import { createStyles } from "antd-style";
+import { useDeferredValue } from "react";
+
+import { useResponsive } from "~/hooks/use-responsive";
+
+import { HTTP_STATUS_CODES } from "./http-status-codes.constants";
+import { useHttpStatusCodesStore } from "./http-status-codes.store";
+import { applyFiltering, CATEGORY_OPTIONS, DEFAULT_CATEGORY } from "./http-status-codes.utils";
+
+const { Text } = Typography;
+
+export const HttpStatusCodesToolbar = () => {
+  const { styles } = useStyles();
+  const { isDesktop } = useResponsive();
+
+  const { category, filter, setCategory, setFilter, resetFilters } = useHttpStatusCodesStore();
+
+  const deferredCategory = useDeferredValue(category);
+  const deferredFilter = useDeferredValue(filter);
+  const filteredCount = applyFiltering({ category: deferredCategory, filter: deferredFilter }).length;
+
+  const hasFilters = category !== DEFAULT_CATEGORY || filter !== "";
+
+  const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFilter(e.target.value);
+  };
+
+  return (
+    <Row gutter={[16, 12]} align="middle" className={styles.toolbar}>
+      <Col xs={24} sm={12} md={6} lg={5}>
+        <Select
+          value={category}
+          onChange={setCategory}
+          options={CATEGORY_OPTIONS}
+          className={styles.select}
+          placeholder="Select category"
+          autoFocus={isDesktop}
+        />
+      </Col>
+
+      <Col xs={24} sm={12} md={8} lg={7}>
+        <Input
+          value={filter}
+          onChange={handleFilterChange}
+          placeholder="Search code, name, or description..."
+          prefix={<SearchOutlined />}
+          allowClear
+          className={styles.input}
+        />
+      </Col>
+
+      <Col xs={12} sm={12} md={4} lg={4}>
+        <Text type="secondary" className={styles.count}>
+          {filteredCount} / {HTTP_STATUS_CODES.length}
+        </Text>
+      </Col>
+
+      <Col xs={12} sm={12} md={6} lg={8}>
+        <Space className={styles.actions}>
+          {hasFilters && (
+            <Button icon={<ClearOutlined />} onClick={resetFilters}>
+              Clear filters
+            </Button>
+          )}
+        </Space>
+      </Col>
+    </Row>
+  );
+};
+
+const useStyles = createStyles(() => ({
+  toolbar: {
+    marginBottom: 16,
+  },
+  select: {
+    width: "100%",
+  },
+  input: {
+    width: "100%",
+  },
+  count: {
+    fontFamily: "monospace",
+  },
+  actions: {
+    display: "flex",
+    justifyContent: "flex-end",
+    width: "100%",
+  },
+}));

--- a/src/screens/common-lists/http-status-codes/http-status-codes.constants.ts
+++ b/src/screens/common-lists/http-status-codes/http-status-codes.constants.ts
@@ -1,0 +1,349 @@
+import type { HttpStatusCodeEntry, HttpStatusCategory } from "./http-status-codes.types";
+
+const MDN_BASE_URL = "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status";
+
+const createEntry = (code: number, name: string, description: string): HttpStatusCodeEntry => {
+  const category = `${Math.floor(code / 100)}xx` as HttpStatusCategory;
+  return {
+    code,
+    name,
+    description,
+    category,
+    mdnUrl: `${MDN_BASE_URL}/${code}`,
+  };
+};
+
+export const HTTP_STATUS_CODES: HttpStatusCodeEntry[] = [
+  // 1xx Informational responses
+  createEntry(
+    100,
+    "Continue",
+    "The server has received the request headers and the client should proceed to send the request body. This interim response indicates that the client should continue the request or ignore the response if the request is already finished."
+  ),
+  createEntry(
+    101,
+    "Switching Protocols",
+    "The requester has asked the server to switch protocols and the server has agreed to do so. This response is sent in response to an Upgrade request header from the client and indicates the protocol the server is switching to."
+  ),
+  createEntry(
+    102,
+    "Processing",
+    "The server has received and is processing the request, but no response is available yet. This prevents the client from timing out and assuming the request was lost. (WebDAV; RFC 2518)"
+  ),
+  createEntry(
+    103,
+    "Early Hints",
+    "Used to return some response headers before final HTTP message. Primarily intended for use with the Link header, letting the user agent start preloading resources while the server prepares a response."
+  ),
+
+  // 2xx Success
+  createEntry(
+    200,
+    "OK",
+    "The request succeeded. The meaning of the success depends on the HTTP method: GET (resource fetched), HEAD (headers sent), PUT/POST (result of action transmitted), TRACE (message body contains the request as received)."
+  ),
+  createEntry(
+    201,
+    "Created",
+    "The request succeeded and a new resource was created as a result. This is typically the response sent after POST requests, or some PUT requests."
+  ),
+  createEntry(
+    202,
+    "Accepted",
+    "The request has been received but not yet acted upon. It is noncommittal, since there is no way in HTTP to later send an asynchronous response indicating the outcome of the request."
+  ),
+  createEntry(
+    203,
+    "Non-Authoritative Information",
+    "The returned metadata is not exactly the same as is available from the origin server, but is collected from a local or third-party copy. This is mostly used for mirrors or backups of another resource."
+  ),
+  createEntry(
+    204,
+    "No Content",
+    "There is no content to send for this request, but the headers may be useful. The user agent may update its cached headers for this resource with the new ones."
+  ),
+  createEntry(
+    205,
+    "Reset Content",
+    "Tells the user agent to reset the document which sent this request. This response is intended for actions which require resetting a form after submission."
+  ),
+  createEntry(
+    206,
+    "Partial Content",
+    "This response code is used when the Range header is sent from the client to request only part of a resource. Used for resumable downloads and streaming."
+  ),
+  createEntry(
+    207,
+    "Multi-Status",
+    "Conveys information about multiple resources, for situations where multiple status codes might be appropriate. The message body is an XML message and can contain separate response codes. (WebDAV; RFC 4918)"
+  ),
+  createEntry(
+    208,
+    "Already Reported",
+    "Used inside a <dav:propstat> response element to avoid repeatedly enumerating the internal members of multiple bindings to the same collection. (WebDAV; RFC 5842)"
+  ),
+  createEntry(
+    226,
+    "IM Used",
+    "The server has fulfilled a GET request for the resource, and the response is a representation of the result of one or more instance-manipulations applied to the current instance. (HTTP Delta encoding; RFC 3229)"
+  ),
+
+  // 3xx Redirection
+  createEntry(
+    300,
+    "Multiple Choices",
+    "The request has more than one possible response. The user agent or user should choose one of them. There is no standardized way of choosing one of the responses, but HTML links to the possibilities are recommended."
+  ),
+  createEntry(
+    301,
+    "Moved Permanently",
+    "The URL of the requested resource has been changed permanently. The new URL is given in the response. Clients should use the new URL for future requests."
+  ),
+  createEntry(
+    302,
+    "Found",
+    "This response code means that the URI of requested resource has been changed temporarily. Further changes in the URI might be made in the future, so the same URI should be used by the client in future requests."
+  ),
+  createEntry(
+    303,
+    "See Other",
+    "The server sent this response to direct the client to get the requested resource at another URI with a GET request. This is typically used after a PUT or POST to redirect to the result of an action."
+  ),
+  createEntry(
+    304,
+    "Not Modified",
+    "This is used for caching purposes. It tells the client that the response has not been modified, so the client can continue to use the same cached version of the response."
+  ),
+  createEntry(
+    305,
+    "Use Proxy",
+    "Defined in a previous version of the HTTP specification to indicate that a requested response must be accessed by a proxy. It has been deprecated due to security concerns regarding in-band configuration of a proxy."
+  ),
+  createEntry(
+    306,
+    "Switch Proxy",
+    "No longer used. Originally meant 'Subsequent requests should use the specified proxy.' This code is no longer used and is reserved."
+  ),
+  createEntry(
+    307,
+    "Temporary Redirect",
+    "The server sends this response to direct the client to get the requested resource at another URI with the same method that was used in the prior request. Unlike 302, the method and body are guaranteed not to change."
+  ),
+  createEntry(
+    308,
+    "Permanent Redirect",
+    "This means that the resource is now permanently located at another URI, specified by the Location header. Unlike 301, the request method is not allowed to change from POST to GET."
+  ),
+
+  // 4xx Client errors
+  createEntry(
+    400,
+    "Bad Request",
+    "The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing)."
+  ),
+  createEntry(
+    401,
+    "Unauthorized",
+    "Although the HTTP standard specifies 'unauthorized', semantically this response means 'unauthenticated'. The client must authenticate itself to get the requested response."
+  ),
+  createEntry(
+    402,
+    "Payment Required",
+    "This response code is reserved for future use. The initial aim for creating this code was using it for digital payment systems, however this status code is used very rarely and no standard convention exists."
+  ),
+  createEntry(
+    403,
+    "Forbidden",
+    "The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401 Unauthorized, the client's identity is known to the server."
+  ),
+  createEntry(
+    404,
+    "Not Found",
+    "The server cannot find the requested resource. In the browser, this means the URL is not recognized. In an API, this can also mean that the endpoint is valid but the resource itself does not exist."
+  ),
+  createEntry(
+    405,
+    "Method Not Allowed",
+    "The request method is known by the server but is not supported by the target resource. For example, an API may not allow calling DELETE on a resource, or the TRACE method for security reasons."
+  ),
+  createEntry(
+    406,
+    "Not Acceptable",
+    "This response is sent when the web server, after performing server-driven content negotiation, doesn't find any content that conforms to the criteria given by the user agent."
+  ),
+  createEntry(
+    407,
+    "Proxy Authentication Required",
+    "This is similar to 401 Unauthorized but authentication is needed to be done by a proxy. The proxy must send a Proxy-Authenticate header field containing a challenge."
+  ),
+  createEntry(
+    408,
+    "Request Timeout",
+    "This response is sent on an idle connection by some servers, even without any previous request by the client. It means that the server would like to shut down this unused connection."
+  ),
+  createEntry(
+    409,
+    "Conflict",
+    "This response is sent when a request conflicts with the current state of the server. The conflict is usually with resources that can have a state (like versioned documents or reservations)."
+  ),
+  createEntry(
+    410,
+    "Gone",
+    "This response is sent when the requested content has been permanently deleted from server, with no forwarding address. Clients are expected to remove their caches and links to the resource."
+  ),
+  createEntry(
+    411,
+    "Length Required",
+    "Server rejected the request because the Content-Length header field is not defined and the server requires it. This is required for requests with a body (POST, PUT)."
+  ),
+  createEntry(
+    412,
+    "Precondition Failed",
+    "The client has indicated preconditions in its headers which the server does not meet. Used with conditional requests using headers like If-Match, If-None-Match, If-Modified-Since."
+  ),
+  createEntry(
+    413,
+    "Payload Too Large",
+    "Request entity is larger than limits defined by server. The server might close the connection or return a Retry-After header field. Previously called 'Request Entity Too Large'."
+  ),
+  createEntry(
+    414,
+    "URI Too Long",
+    "The URI requested by the client is longer than the server is willing to interpret. This is rare, and usually happens when a GET request contains too much data in its query string."
+  ),
+  createEntry(
+    415,
+    "Unsupported Media Type",
+    "The media format of the requested data is not supported by the server, so the server is rejecting the request. For example, sending XML when the server only accepts JSON."
+  ),
+  createEntry(
+    416,
+    "Range Not Satisfiable",
+    "The range specified by the Range header field in the request cannot be fulfilled. It's possible that the range is outside the size of the target URI's data."
+  ),
+  createEntry(
+    417,
+    "Expectation Failed",
+    "This response code means the expectation indicated by the Expect request header field cannot be met by the server. The server was unable to fulfill the client's expectation."
+  ),
+  createEntry(
+    418,
+    "I'm a teapot",
+    "The server refuses the attempt to brew coffee with a teapot. This code was defined in 1998 as an April Fools' joke in RFC 2324, Hyper Text Coffee Pot Control Protocol. Some websites use this for requests they do not wish to handle."
+  ),
+  createEntry(
+    421,
+    "Misdirected Request",
+    "The request was directed at a server that is not able to produce a response. This can be sent by a server that is not configured to produce responses for the combination of scheme and authority included in the request URI."
+  ),
+  createEntry(
+    422,
+    "Unprocessable Entity",
+    "The request was well-formed but was unable to be followed due to semantic errors. Commonly used in REST APIs when the request body is syntactically correct but semantically invalid. (WebDAV; RFC 4918)"
+  ),
+  createEntry(
+    423,
+    "Locked",
+    "The resource that is being accessed is locked. This status code is primarily used by WebDAV to indicate that a resource is locked by another client. (WebDAV; RFC 4918)"
+  ),
+  createEntry(
+    424,
+    "Failed Dependency",
+    "The request failed due to failure of a previous request. This indicates that a method could not be performed because the requested action depended on another action that failed. (WebDAV; RFC 4918)"
+  ),
+  createEntry(
+    425,
+    "Too Early",
+    "Indicates that the server is unwilling to risk processing a request that might be replayed. Used with TLS 1.3 early data (0-RTT) to prevent replay attacks. (RFC 8470)"
+  ),
+  createEntry(
+    426,
+    "Upgrade Required",
+    "The server refuses to perform the request using the current protocol but might be willing to do so after the client upgrades to a different protocol. The server sends an Upgrade header to indicate required protocols."
+  ),
+  createEntry(
+    428,
+    "Precondition Required",
+    "The origin server requires the request to be conditional. This response is intended to prevent the 'lost update' problem, where a client GETs a resource's state, modifies it, and PUTs it back while a third party has modified the state on the server."
+  ),
+  createEntry(
+    429,
+    "Too Many Requests",
+    "The user has sent too many requests in a given amount of time ('rate limiting'). The response may include a Retry-After header indicating how long to wait before making a new request."
+  ),
+  createEntry(
+    431,
+    "Request Header Fields Too Large",
+    "The server is unwilling to process the request because its header fields are too large. The request may be resubmitted after reducing the size of the request header fields."
+  ),
+  createEntry(
+    451,
+    "Unavailable For Legal Reasons",
+    "The user agent requested a resource that cannot legally be provided, such as a web page censored by a government. The number 451 is a reference to the novel Fahrenheit 451."
+  ),
+
+  // 5xx Server errors
+  createEntry(
+    500,
+    "Internal Server Error",
+    "The server has encountered a situation it does not know how to handle. This is a generic 'catch-all' response when the server encounters an unexpected condition."
+  ),
+  createEntry(
+    501,
+    "Not Implemented",
+    "The request method is not supported by the server and cannot be handled. The only methods that servers are required to support are GET and HEAD, which must never return this code."
+  ),
+  createEntry(
+    502,
+    "Bad Gateway",
+    "This error response means that the server, while working as a gateway to get a response needed to handle the request, got an invalid response from the upstream server."
+  ),
+  createEntry(
+    503,
+    "Service Unavailable",
+    "The server is not ready to handle the request. Common causes are a server that is down for maintenance or that is overloaded. A Retry-After header may indicate when to retry."
+  ),
+  createEntry(
+    504,
+    "Gateway Timeout",
+    "This error response is given when the server is acting as a gateway and cannot get a response in time from the upstream server needed to complete the request."
+  ),
+  createEntry(
+    505,
+    "HTTP Version Not Supported",
+    "The HTTP version used in the request is not supported by the server. The server indicates which HTTP versions it supports in the response."
+  ),
+  createEntry(
+    506,
+    "Variant Also Negotiates",
+    "The server has an internal configuration error: the chosen variant resource is configured to engage in transparent content negotiation itself, and is therefore not a proper end point in the negotiation process. (RFC 2295)"
+  ),
+  createEntry(
+    507,
+    "Insufficient Storage",
+    "The method could not be performed on the resource because the server is unable to store the representation needed to successfully complete the request. (WebDAV; RFC 4918)"
+  ),
+  createEntry(
+    508,
+    "Loop Detected",
+    "The server detected an infinite loop while processing the request. The server terminates the operation to prevent infinite recursion. (WebDAV; RFC 5842)"
+  ),
+  createEntry(
+    510,
+    "Not Extended",
+    "Further extensions to the request are required for the server to fulfill it. The server will inform the client about which extensions are required. (RFC 2774)"
+  ),
+  createEntry(
+    511,
+    "Network Authentication Required",
+    "Indicates that the client needs to authenticate to gain network access. Intended for use by intercepting proxies used to control access to the network (e.g., captive portals). (RFC 6585)"
+  ),
+];
+
+export const CATEGORY_LABELS: Record<string, string> = {
+  "1xx": "1xx Informational",
+  "2xx": "2xx Success",
+  "3xx": "3xx Redirection",
+  "4xx": "4xx Client Error",
+  "5xx": "5xx Server Error",
+};

--- a/src/screens/common-lists/http-status-codes/http-status-codes.store.ts
+++ b/src/screens/common-lists/http-status-codes/http-status-codes.store.ts
@@ -1,0 +1,45 @@
+import { create } from "zustand";
+import { createJSONStorage, devtools, persist } from "zustand/middleware";
+
+import type { HttpStatusCategoryFilter } from "./http-status-codes.types";
+import { DEFAULT_CATEGORY, DEFAULT_FILTER, DEFAULT_PAGE, DEFAULT_PAGE_SIZE } from "./http-status-codes.utils";
+
+interface HttpStatusCodesState {
+  category: HttpStatusCategoryFilter;
+  filter: string;
+  page: number;
+  pageSize: number;
+  setCategory: (category: HttpStatusCategoryFilter) => void;
+  setFilter: (filter: string) => void;
+  setPage: (page: number) => void;
+  setPageSize: (pageSize: number) => void;
+  resetFilters: () => void;
+}
+
+const stateCreator = (set: (partial: Partial<HttpStatusCodesState>) => void): HttpStatusCodesState => ({
+  category: DEFAULT_CATEGORY,
+  filter: DEFAULT_FILTER,
+  page: DEFAULT_PAGE,
+  pageSize: DEFAULT_PAGE_SIZE,
+  setCategory: (category) => set({ category, page: DEFAULT_PAGE }),
+  setFilter: (filter) => set({ filter, page: DEFAULT_PAGE }),
+  setPage: (page) => set({ page }),
+  setPageSize: (pageSize) => set({ pageSize, page: DEFAULT_PAGE }),
+  resetFilters: () =>
+    set({
+      category: DEFAULT_CATEGORY,
+      filter: DEFAULT_FILTER,
+      page: DEFAULT_PAGE,
+    }),
+});
+
+const PERSISTED_STORE_NAME = "etoolbox-http-status-codes";
+
+const persistedStateCreator = persist<HttpStatusCodesState>(stateCreator, {
+  name: PERSISTED_STORE_NAME,
+  storage: createJSONStorage(() => localStorage),
+});
+
+export const useHttpStatusCodesStore = create<HttpStatusCodesState>()(
+  devtools(persistedStateCreator, { name: PERSISTED_STORE_NAME })
+);

--- a/src/screens/common-lists/http-status-codes/http-status-codes.tsx
+++ b/src/screens/common-lists/http-status-codes/http-status-codes.tsx
@@ -1,0 +1,34 @@
+import { ApiOutlined } from "@ant-design/icons";
+import { Flex } from "antd";
+import { createStyles } from "antd-style";
+
+import { ScreenContainer } from "~/components/ui/screen-container";
+import { ScreenHeader } from "~/components/ui/screen-header";
+
+import { HttpStatusCodesTable } from "./http-status-codes-table";
+import { HttpStatusCodesToolbar } from "./http-status-codes-toolbar";
+
+export const HttpStatusCodes = () => {
+  const { styles } = useStyles();
+
+  return (
+    <ScreenContainer>
+      <Flex vertical gap="small" className={styles.container}>
+        <ScreenHeader
+          icon={<ApiOutlined />}
+          title="HTTP Status Codes"
+          description="Browse and search through all standard HTTP response status codes with their official descriptions from MDN Web Docs"
+        />
+
+        <HttpStatusCodesToolbar />
+        <HttpStatusCodesTable />
+      </Flex>
+    </ScreenContainer>
+  );
+};
+
+const useStyles = createStyles(() => ({
+  container: {
+    width: "100%",
+  },
+}));

--- a/src/screens/common-lists/http-status-codes/http-status-codes.types.ts
+++ b/src/screens/common-lists/http-status-codes/http-status-codes.types.ts
@@ -1,0 +1,11 @@
+export interface HttpStatusCodeEntry {
+  code: number;
+  name: string;
+  description: string;
+  category: HttpStatusCategory;
+  mdnUrl: string;
+}
+
+export type HttpStatusCategory = "1xx" | "2xx" | "3xx" | "4xx" | "5xx";
+
+export type HttpStatusCategoryFilter = "all" | HttpStatusCategory;

--- a/src/screens/common-lists/http-status-codes/http-status-codes.utils.ts
+++ b/src/screens/common-lists/http-status-codes/http-status-codes.utils.ts
@@ -1,0 +1,46 @@
+import { CATEGORY_LABELS, HTTP_STATUS_CODES } from "./http-status-codes.constants";
+import type { HttpStatusCodeEntry, HttpStatusCategoryFilter } from "./http-status-codes.types";
+
+export const CATEGORIES: HttpStatusCategoryFilter[] = ["1xx", "2xx", "3xx", "4xx", "5xx"];
+
+export const CATEGORY_OPTIONS = [
+  { value: "all" as const, label: "All categories" },
+  ...CATEGORIES.map((category) => ({
+    value: category,
+    label: CATEGORY_LABELS[category] ?? category,
+  })),
+];
+
+interface ApplyFilteringArgs {
+  category: HttpStatusCategoryFilter;
+  filter: string;
+}
+
+export const applyFiltering = ({ category, filter }: ApplyFilteringArgs): HttpStatusCodeEntry[] => {
+  let results = HTTP_STATUS_CODES.slice();
+
+  if (category && category !== "all") {
+    results = results.filter((entry) => entry.category === category);
+  }
+
+  if (filter) {
+    const filterLowercase = filter.toLowerCase();
+
+    results = results.filter((entry) => {
+      return (
+        entry.code.toString().includes(filterLowercase) ||
+        entry.name.toLowerCase().includes(filterLowercase) ||
+        entry.description.toLowerCase().includes(filterLowercase)
+      );
+    });
+  }
+
+  return results;
+};
+
+export const DEFAULT_CATEGORY: HttpStatusCategoryFilter = "all";
+export const DEFAULT_FILTER = "";
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_PAGE_SIZE = 200;
+
+export const PAGE_SIZE_OPTIONS = [10, 25, 50, 100, 200];

--- a/src/screens/common-lists/http-status-codes/use-http-status-codes-columns.tsx
+++ b/src/screens/common-lists/http-status-codes/use-http-status-codes-columns.tsx
@@ -1,0 +1,111 @@
+import { LinkOutlined } from "@ant-design/icons";
+import { Tag, Tooltip, Typography } from "antd";
+import type { ColumnsType } from "antd/es/table";
+import { createStyles } from "antd-style";
+
+import { useResponsive } from "~/hooks/use-responsive";
+
+import { CATEGORY_LABELS } from "./http-status-codes.constants";
+import type { HttpStatusCodeEntry } from "./http-status-codes.types";
+
+const { Text } = Typography;
+
+const CATEGORY_COLORS: Record<string, string> = {
+  "1xx": "blue",
+  "2xx": "green",
+  "3xx": "orange",
+  "4xx": "red",
+  "5xx": "purple",
+};
+
+export const useHttpStatusCodesColumns = (): ColumnsType<HttpStatusCodeEntry> => {
+  const { styles } = useStyles();
+  const { isMobile } = useResponsive();
+
+  return [
+    {
+      title: "Code",
+      dataIndex: "code",
+      key: "code",
+      width: isMobile ? 60 : 80,
+      sorter: (a, b) => a.code - b.code,
+      render: (code: number) => (
+        <Text strong className={styles.codeText}>
+          {code}
+        </Text>
+      ),
+    },
+    {
+      title: "Name",
+      dataIndex: "name",
+      key: "name",
+      width: isMobile ? 180 : 280,
+      sorter: (a, b) => a.name.localeCompare(b.name),
+      render: (name: string, record: HttpStatusCodeEntry) => (
+        <div className={styles.nameCell}>
+          <div className={styles.nameRow}>
+            <Text strong className={styles.nameText}>
+              {name}
+            </Text>
+            <Tooltip title="View on MDN">
+              <a href={record.mdnUrl} target="_blank" rel="noopener noreferrer" className={styles.mdnLink}>
+                <LinkOutlined />
+              </a>
+            </Tooltip>
+          </div>
+          <Tag color={CATEGORY_COLORS[record.category] ?? "default"} className={styles.categoryTag}>
+            {CATEGORY_LABELS[record.category]?.split(" ")[1] ?? record.category}
+          </Tag>
+        </div>
+      ),
+    },
+    {
+      title: "Description",
+      dataIndex: "description",
+      key: "description",
+      render: (description: string) => <Text className={styles.description}>{description}</Text>,
+    },
+  ];
+};
+
+const useStyles = createStyles(({ token }) => ({
+  codeText: {
+    fontSize: 16,
+    fontFamily: "monospace",
+    color: token.colorPrimary,
+  },
+  categoryTag: {
+    fontSize: 10,
+    marginRight: 0,
+    padding: "0 4px",
+  },
+  nameCell: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    gap: 4,
+  },
+  nameRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+  },
+  nameText: {
+    fontSize: 13,
+  },
+  mdnLink: {
+    color: token.colorTextSecondary,
+    fontSize: 14,
+    "&:hover": {
+      color: token.colorPrimary,
+    },
+  },
+  description: {
+    margin: "0 !important",
+    fontSize: 12,
+    color: token.colorTextSecondary,
+    lineHeight: 1.6,
+    whiteSpace: "normal",
+    wordBreak: "break-word",
+  },
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2175,8 +2175,8 @@ __metadata:
   linkType: hard
 
 "@tanstack/react-router@npm:^1.144.0":
-  version: 1.146.2
-  resolution: "@tanstack/react-router@npm:1.146.2"
+  version: 1.147.0
+  resolution: "@tanstack/react-router@npm:1.147.0"
   dependencies:
     "@tanstack/history": "npm:1.145.7"
     "@tanstack/react-store": "npm:^0.8.0"
@@ -2187,7 +2187,7 @@ __metadata:
   peerDependencies:
     react: ">=18.0.0 || >=19.0.0"
     react-dom: ">=18.0.0 || >=19.0.0"
-  checksum: 10c0/538d7828fbe441d919c7e8dd633bab64a2df27ddb8d3ee301ab07c9e3bf729805ac109ff38f543bc1a0377b4b29b5cadccfea09869c536d333f7020d7e136579
+  checksum: 10c0/8437887b9b0304871c36febd4709007bae8e234d01be642cc1056e001407a378dba19313c4301434150e326a7c2d771282655de3205ef6d74fe57fab5a5d3ff4
   languageName: node
   linkType: hard
 
@@ -2395,20 +2395,20 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 25.0.3
-  resolution: "@types/node@npm:25.0.3"
+  version: 25.0.5
+  resolution: "@types/node@npm:25.0.5"
   dependencies:
     undici-types: "npm:~7.16.0"
-  checksum: 10c0/b7568f0d765d9469621615e2bb257c7fd1953d95e9acbdb58dffb6627a2c4150d405a4600aa1ad8a40182a94fe5f903cafd3c0a2f5132814debd0e3bfd61f835
+  checksum: 10c0/e92f8e29e17ff2d75f774233cad5b96bf7b253d24979162e1fff85993509a3511afe15a456217881f8e59fd5ff0b0d86067e33f57d599d1939a6d73c4f4806c7
   languageName: node
   linkType: hard
 
 "@types/node@npm:^24.10.1":
-  version: 24.10.4
-  resolution: "@types/node@npm:24.10.4"
+  version: 24.10.6
+  resolution: "@types/node@npm:24.10.6"
   dependencies:
     undici-types: "npm:~7.16.0"
-  checksum: 10c0/069639cb7233ee747df1897b5e784f6b6c5da765c96c94773c580aac888fa1a585048d2a6e95eb8302d89c7a9df75801c8b5a0b7d0221d4249059cf09a5f4228
+  checksum: 10c0/4c93fb9c4ad38ef0738a34815d84bb091cf6e7af7d51d58f20a8600a8a189edbf0fb54c4f86e344b2199db7bda04fecf17c9d171055ff7a9aa8333b3b96fce4c
   languageName: node
   linkType: hard
 
@@ -2488,11 +2488,11 @@ __metadata:
   linkType: hard
 
 "@types/react@npm:*, @types/react@npm:^19.2.7":
-  version: 19.2.7
-  resolution: "@types/react@npm:19.2.7"
+  version: 19.2.8
+  resolution: "@types/react@npm:19.2.8"
   dependencies:
     csstype: "npm:^3.2.2"
-  checksum: 10c0/a7b75f1f9fcb34badd6f84098be5e35a0aeca614bc91f93d2698664c0b2ba5ad128422bd470ada598238cebe4f9e604a752aead7dc6f5a92261d0c7f9b27cfd1
+  checksum: 10c0/832834998c4ee971fca72ecf1eb95dc924ad3931a2112c687a4dae498aabd115c5fa4db09186853e34a646226b0223808c8f867df03d17601168f9cf119448de
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes Description

- Add new HTTP Status Codes screen under "Common Lists"
- Searchable table with all standard HTTP response codes
- Filter by category (1xx, 2xx, 3xx, 4xx, 5xx)
- Official descriptions sourced from MDN Web Docs

## Checklist

- [x] code follows project [coding guidelines](https://github.com/amwebexpert/chrome-extensions-collection/blob/master/packages/coding-guide-helper/public/markdowns/table-of-content.md).
- [x] documentation has been updated (if applicable).
- [ ] tests have been added or updated (if applicable).
- [ ] e2e tests completed

## Screen capture(s) or recording

<img width="3010" height="1714" alt="image" src="https://github.com/user-attachments/assets/0ddac9f7-1b51-4142-a326-8979f0112ea8" />
