### PR TITLE
feat: http header list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ cypress/videos
 /coverage-reports-temp
 /coverage-all
 /.yarn
+.playwright-mcp

--- a/docs/assets/browser-D1auik0Y.js
+++ b/docs/assets/browser-D1auik0Y.js
@@ -1,1 +1,0 @@
-import{t as e}from"./index-D4mSplAS.js";export default e();

--- a/docs/assets/browser-Pu9p1B6r.js
+++ b/docs/assets/browser-Pu9p1B6r.js
@@ -1,0 +1,1 @@
+import{t as e}from"./index-B9G5Xnh4.js";export default e();

--- a/docs/index.html
+++ b/docs/index.html
@@ -116,7 +116,7 @@
     <link rel="icon" type="image/ico" href="favicon.ico" />
 
     <title>Web Toolbox</title>
-    <script type="module" crossorigin src="/etoolbox/assets/index-D4mSplAS.js"></script>
+    <script type="module" crossorigin src="/etoolbox/assets/index-B9G5Xnh4.js"></script>
     <link rel="stylesheet" crossorigin href="/etoolbox/assets/index-3ATQF-qn.css">
   </head>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-toolbox",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "author": "amwebexpert@gmail.com",
   "repository": "https://github.com/amwebexpert/etoolbox",
   "contributors": [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,9 +6,9 @@ export const APP_VERSION_INFO = Object.freeze({
   DESCRIPTION: "Collection of web development utilities. Like a Swiss knife for web developers.",
   REPOSITORY: "https://github.com/amwebexpert/etoolbox",
   AUTHOR: "amwebexpert@gmail.com",
-  VERSION: "4.1.0",
+  VERSION: "4.2.0",
   VERSION_DATE: "2026-01-10",
-  VERSION_DATE_ISO: "2026-01-10T11:45:08.963Z",
+  VERSION_DATE_ISO: "2026-01-10T12:10:24.163Z",
 });
 
-export const LONG_VERSION_DATE = "4.1.0 (2026-01-10)";
+export const LONG_VERSION_DATE = "4.2.0 (2026-01-10)";

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -9,6 +9,7 @@ import { NamedColors } from "~/screens/colors/named/named-colors";
 import { ColorPicker } from "~/screens/colors/picker/color-picker";
 import { CommonLists } from "~/screens/common-lists/common-lists";
 import { HtmlEntities } from "~/screens/common-lists/html-entities/html-entities";
+import { HttpHeaders } from "~/screens/common-lists/http-headers/http-headers";
 import { HttpStatusCodes } from "~/screens/common-lists/http-status-codes/http-status-codes";
 import { MimeTypes } from "~/screens/common-lists/mime-types/mime-types";
 import { CsvParser } from "~/screens/csv-parser/csv-parser";
@@ -235,6 +236,12 @@ const httpStatusCodesRoute = createRoute({
   component: HttpStatusCodes,
 });
 
+const httpHeadersRoute = createRoute({
+  getParentRoute: () => commonListsRoute,
+  path: "/http-headers",
+  component: HttpHeaders,
+});
+
 const githubUserProjectsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/github-user-projects",
@@ -285,7 +292,13 @@ const routeTree = rootRoute.addChildren([
   jwtDecoderRoute,
   qrcodeRoute.addChildren([qrcodeIndexRoute, qrcodeGeneratorRoute, qrcodeDecoderRoute]),
   imageOcrRoute,
-  commonListsRoute.addChildren([commonListsIndexRoute, mimeTypesRoute, htmlEntitiesRoute, httpStatusCodesRoute]),
+  commonListsRoute.addChildren([
+    commonListsIndexRoute,
+    mimeTypesRoute,
+    htmlEntitiesRoute,
+    httpStatusCodesRoute,
+    httpHeadersRoute,
+  ]),
   githubUserProjectsRoute,
   dateConverterRoute,
   csvParserRoute,

--- a/src/screens/common-lists/common-lists.tsx
+++ b/src/screens/common-lists/common-lists.tsx
@@ -4,6 +4,7 @@ const TAB_ITEMS = [
   { key: "/common-lists/mime-types", label: "Mime-types" },
   { key: "/common-lists/html-entities", label: "HTML Entities" },
   { key: "/common-lists/http-status-codes", label: "HTTP Status Codes" },
+  { key: "/common-lists/http-headers", label: "HTTP Headers" },
 ];
 
 export const CommonLists = () => {

--- a/src/screens/common-lists/http-headers/http-headers-table.tsx
+++ b/src/screens/common-lists/http-headers/http-headers-table.tsx
@@ -1,0 +1,64 @@
+import { Table } from "antd";
+import { createStyles } from "antd-style";
+import { useDeferredValue } from "react";
+
+import { useResponsive } from "~/hooks/use-responsive";
+
+import { useHttpHeadersStore } from "./http-headers.store";
+import { applyFiltering, PAGE_SIZE_OPTIONS } from "./http-headers.utils";
+import { useHttpHeadersColumns } from "./use-http-headers-columns";
+
+export const HttpHeadersTable = () => {
+  const { styles } = useStyles();
+  const { isMobile } = useResponsive();
+  const columns = useHttpHeadersColumns();
+
+  const { category, type, filter, page, pageSize, setPage, setPageSize } = useHttpHeadersStore();
+
+  const deferredCategory = useDeferredValue(category);
+  const deferredType = useDeferredValue(type);
+  const deferredFilter = useDeferredValue(filter);
+
+  const filteredHeaders = applyFiltering({ category: deferredCategory, type: deferredType, filter: deferredFilter });
+
+  const handlePageChange = (newPage: number, newPageSize: number) => {
+    setPage(newPage);
+    if (newPageSize !== pageSize) {
+      setPageSize(newPageSize);
+    }
+  };
+
+  return (
+    <Table
+      dataSource={filteredHeaders}
+      columns={columns}
+      rowKey={(record) => record.name}
+      pagination={{
+        current: page,
+        pageSize: pageSize,
+        total: filteredHeaders.length,
+        showSizeChanger: true,
+        pageSizeOptions: PAGE_SIZE_OPTIONS.map(String),
+        showTotal: (total, range) => `${range[0]}-${range[1]} of ${total} headers`,
+        size: isMobile ? "small" : "default",
+        onChange: handlePageChange,
+      }}
+      size="small"
+      className={styles.table}
+    />
+  );
+};
+
+const useStyles = createStyles(({ token }) => ({
+  table: {
+    ".ant-table-thead > tr > th": {
+      backgroundColor: token.colorPrimaryBg,
+    },
+    ".ant-table-tbody > tr > td": {
+      borderBottom: "none",
+      paddingBlock: 8,
+      paddingInline: 8,
+      verticalAlign: "top",
+    },
+  },
+}));

--- a/src/screens/common-lists/http-headers/http-headers-toolbar.tsx
+++ b/src/screens/common-lists/http-headers/http-headers-toolbar.tsx
@@ -1,0 +1,106 @@
+import { ClearOutlined, SearchOutlined } from "@ant-design/icons";
+import { Button, Col, Input, Row, Select, Space, Typography } from "antd";
+import { createStyles } from "antd-style";
+import { useDeferredValue } from "react";
+
+import { useResponsive } from "~/hooks/use-responsive";
+
+import { HTTP_HEADERS } from "./http-headers.constants";
+import { useHttpHeadersStore } from "./http-headers.store";
+import { applyFiltering, CATEGORY_OPTIONS, DEFAULT_CATEGORY, DEFAULT_TYPE, TYPE_OPTIONS } from "./http-headers.utils";
+
+const { Text } = Typography;
+
+export const HttpHeadersToolbar = () => {
+  const { styles } = useStyles();
+  const { isDesktop } = useResponsive();
+
+  const { category, type, filter, setCategory, setType, setFilter, resetFilters } = useHttpHeadersStore();
+
+  const deferredCategory = useDeferredValue(category);
+  const deferredType = useDeferredValue(type);
+  const deferredFilter = useDeferredValue(filter);
+  const filteredCount = applyFiltering({
+    category: deferredCategory,
+    type: deferredType,
+    filter: deferredFilter,
+  }).length;
+
+  const hasFilters = category !== DEFAULT_CATEGORY || type !== DEFAULT_TYPE || filter !== "";
+
+  const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFilter(e.target.value);
+  };
+
+  return (
+    <Row gutter={[16, 12]} align="middle" className={styles.toolbar}>
+      <Col xs={24} sm={12} md={5} lg={4}>
+        <Select
+          value={category}
+          onChange={setCategory}
+          options={CATEGORY_OPTIONS}
+          className={styles.select}
+          placeholder="Select category"
+          autoFocus={isDesktop}
+        />
+      </Col>
+
+      <Col xs={24} sm={12} md={4} lg={3}>
+        <Select
+          value={type}
+          onChange={setType}
+          options={TYPE_OPTIONS}
+          className={styles.select}
+          placeholder="Select type"
+        />
+      </Col>
+
+      <Col xs={24} sm={12} md={7} lg={6}>
+        <Input
+          value={filter}
+          onChange={handleFilterChange}
+          placeholder="Search header name or description..."
+          prefix={<SearchOutlined />}
+          allowClear
+          className={styles.input}
+        />
+      </Col>
+
+      <Col xs={12} sm={6} md={4} lg={3}>
+        <Text type="secondary" className={styles.count}>
+          {filteredCount} / {HTTP_HEADERS.length}
+        </Text>
+      </Col>
+
+      <Col xs={12} sm={6} md={4} lg={8}>
+        <Space className={styles.actions}>
+          {hasFilters && (
+            <Button icon={<ClearOutlined />} onClick={resetFilters}>
+              Clear filters
+            </Button>
+          )}
+        </Space>
+      </Col>
+    </Row>
+  );
+};
+
+const useStyles = createStyles(() => ({
+  toolbar: {
+    marginBottom: 16,
+  },
+  select: {
+    width: "100%",
+  },
+  input: {
+    width: "100%",
+  },
+  count: {
+    fontFamily: "monospace",
+  },
+  actions: {
+    display: "flex",
+    justifyContent: "flex-end",
+    width: "100%",
+  },
+}));

--- a/src/screens/common-lists/http-headers/http-headers.constants.ts
+++ b/src/screens/common-lists/http-headers/http-headers.constants.ts
@@ -1,0 +1,487 @@
+import type { HttpHeaderEntry, HttpHeaderCategory, HttpHeaderType } from "./http-headers.types";
+
+const MDN_BASE_URL = "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers";
+
+const createEntry = (
+  name: string,
+  description: string,
+  type: HttpHeaderType,
+  category: HttpHeaderCategory
+): HttpHeaderEntry => ({
+  name,
+  description,
+  type,
+  category,
+  mdnUrl: `${MDN_BASE_URL}/${name}`,
+});
+
+export const HTTP_HEADERS: HttpHeaderEntry[] = [
+  // Authentication
+  createEntry(
+    "WWW-Authenticate",
+    "Defines the authentication method that should be used to access a resource.",
+    "response",
+    "authentication"
+  ),
+  createEntry(
+    "Authorization",
+    "Contains the credentials to authenticate a user-agent with a server.",
+    "request",
+    "authentication"
+  ),
+  createEntry(
+    "Proxy-Authenticate",
+    "Defines the authentication method that should be used to access a resource behind a proxy server.",
+    "response",
+    "authentication"
+  ),
+  createEntry(
+    "Proxy-Authorization",
+    "Contains the credentials to authenticate a user agent with a proxy server.",
+    "request",
+    "authentication"
+  ),
+
+  // Caching
+  createEntry("Age", "The time, in seconds, that the object has been in a proxy cache.", "response", "caching"),
+  createEntry("Cache-Control", "Directives for caching mechanisms in both requests and responses.", "both", "caching"),
+  createEntry(
+    "Clear-Site-Data",
+    "Clears browsing data (cookies, storage, cache) associated with the requesting website.",
+    "response",
+    "caching"
+  ),
+  createEntry("Expires", "The date/time after which the response is considered stale.", "response", "caching"),
+  createEntry(
+    "No-Vary-Search",
+    "Specifies a set of rules that define how a URL's query parameters will affect cache matching.",
+    "response",
+    "caching"
+  ),
+
+  // Conditionals
+  createEntry(
+    "Last-Modified",
+    "The last modification date of the resource, used to compare several versions of the same resource.",
+    "response",
+    "conditionals"
+  ),
+  createEntry(
+    "ETag",
+    "A unique string identifying the version of the resource. Conditional requests using If-Match and If-None-Match use this value.",
+    "response",
+    "conditionals"
+  ),
+  createEntry(
+    "If-Match",
+    "Makes the request conditional, and applies the method only if the stored resource matches one of the given ETags.",
+    "request",
+    "conditionals"
+  ),
+  createEntry(
+    "If-None-Match",
+    "Makes the request conditional, and applies the method only if the stored resource doesn't match any of the given ETags.",
+    "request",
+    "conditionals"
+  ),
+  createEntry(
+    "If-Modified-Since",
+    "Makes the request conditional, and expects the resource to be transmitted only if it has been modified after the given date.",
+    "request",
+    "conditionals"
+  ),
+  createEntry(
+    "If-Unmodified-Since",
+    "Makes the request conditional, and expects the resource to be transmitted only if it has not been modified after the given date.",
+    "request",
+    "conditionals"
+  ),
+  createEntry(
+    "Vary",
+    "Determines how to match request headers to decide whether a cached response can be used rather than requesting a fresh one.",
+    "response",
+    "conditionals"
+  ),
+
+  // Connection management
+  createEntry(
+    "Connection",
+    "Controls whether the network connection stays open after the current transaction finishes.",
+    "both",
+    "connection"
+  ),
+  createEntry("Keep-Alive", "Controls how long a persistent connection should stay open.", "both", "connection"),
+
+  // Content negotiation
+  createEntry(
+    "Accept",
+    "Informs the server about the types of data that can be sent back.",
+    "request",
+    "content-negotiation"
+  ),
+  createEntry(
+    "Accept-Encoding",
+    "The encoding algorithm, usually a compression algorithm, that can be used on the resource sent back.",
+    "request",
+    "content-negotiation"
+  ),
+  createEntry(
+    "Accept-Language",
+    "Informs the server about the human language the server is expected to send back.",
+    "request",
+    "content-negotiation"
+  ),
+
+  // Controls
+  createEntry(
+    "Expect",
+    "Indicates expectations that need to be fulfilled by the server to properly handle the request.",
+    "request",
+    "controls"
+  ),
+  createEntry(
+    "Max-Forwards",
+    "When using TRACE, indicates the maximum number of hops the request can do before being reflected to the sender.",
+    "request",
+    "controls"
+  ),
+
+  // Cookies
+  createEntry(
+    "Cookie",
+    "Contains stored HTTP cookies previously sent by the server with the Set-Cookie header.",
+    "request",
+    "cookies"
+  ),
+  createEntry("Set-Cookie", "Send cookies from the server to the user agent.", "response", "cookies"),
+
+  // CORS
+  createEntry(
+    "Access-Control-Allow-Credentials",
+    "Indicates whether the response to the request can be exposed when the credentials flag is true.",
+    "response",
+    "cors"
+  ),
+  createEntry(
+    "Access-Control-Allow-Headers",
+    "Used in response to a preflight request to indicate which HTTP headers can be used when making the actual request.",
+    "response",
+    "cors"
+  ),
+  createEntry(
+    "Access-Control-Allow-Methods",
+    "Specifies the methods allowed when accessing the resource in response to a preflight request.",
+    "response",
+    "cors"
+  ),
+  createEntry(
+    "Access-Control-Allow-Origin",
+    "Indicates whether the response can be shared, via returning the origin from which content was fetched.",
+    "response",
+    "cors"
+  ),
+  createEntry(
+    "Access-Control-Expose-Headers",
+    "Indicates which headers can be exposed as part of the response by listing their names.",
+    "response",
+    "cors"
+  ),
+  createEntry(
+    "Access-Control-Max-Age",
+    "Indicates how long the results of a preflight request can be cached.",
+    "response",
+    "cors"
+  ),
+  createEntry(
+    "Access-Control-Request-Headers",
+    "Used when issuing a preflight request to let the server know which HTTP headers will be used when the actual request is made.",
+    "request",
+    "cors"
+  ),
+  createEntry(
+    "Access-Control-Request-Method",
+    "Used when issuing a preflight request to let the server know which HTTP method will be used when the actual request is made.",
+    "request",
+    "cors"
+  ),
+  createEntry("Origin", "Indicates where a fetch originates from.", "request", "cors"),
+  createEntry(
+    "Timing-Allow-Origin",
+    "Specifies origins that are allowed to see values of attributes retrieved via features of the Resource Timing API.",
+    "response",
+    "cors"
+  ),
+
+  // Downloads
+  createEntry(
+    "Content-Disposition",
+    "Indicates if the resource transmitted should be displayed inline or if it should be handled like a download.",
+    "response",
+    "downloads"
+  ),
+
+  // Message body information
+  createEntry("Content-Length", "The size of the resource, in decimal number of bytes.", "both", "message-body"),
+  createEntry("Content-Type", "Indicates the media type of the resource.", "both", "message-body"),
+  createEntry("Content-Encoding", "Used to specify the compression algorithm.", "both", "message-body"),
+  createEntry("Content-Language", "Describes the human language(s) intended for the audience.", "both", "message-body"),
+  createEntry("Content-Location", "Indicates an alternate location for the returned data.", "response", "message-body"),
+
+  // Proxies
+  createEntry(
+    "Forwarded",
+    "Contains information from the client-facing side of proxy servers that is altered or lost when a proxy is involved in the path of the request.",
+    "request",
+    "proxies"
+  ),
+  createEntry(
+    "Via",
+    "Added by proxies, both forward and reverse proxies, and can appear in the request headers and the response headers.",
+    "both",
+    "proxies"
+  ),
+
+  // Redirects
+  createEntry("Location", "Indicates the URL to redirect a page to.", "response", "redirects"),
+  createEntry(
+    "Refresh",
+    'Directs the browser to reload the page or redirect to another. Same as the meta http-equiv="refresh" element.',
+    "response",
+    "redirects"
+  ),
+
+  // Request context
+  createEntry(
+    "From",
+    "Contains an Internet email address for a human user who controls the requesting user agent.",
+    "request",
+    "request-context"
+  ),
+  createEntry(
+    "Host",
+    "Specifies the host and port number of the server to which the request is being sent.",
+    "request",
+    "request-context"
+  ),
+  createEntry(
+    "Referer",
+    "The address of the previous web page from which a link to the currently requested page was followed.",
+    "request",
+    "request-context"
+  ),
+  createEntry(
+    "Referrer-Policy",
+    "Governs which referrer information sent in the Referer header should be included with requests made.",
+    "response",
+    "request-context"
+  ),
+  createEntry(
+    "User-Agent",
+    "Contains a characteristic string that allows the network protocol peers to identify the application type, OS, software vendor, or version of the requesting software user agent.",
+    "request",
+    "request-context"
+  ),
+
+  // Response context
+  createEntry(
+    "Allow",
+    "Lists the set of HTTP request methods supported by a resource.",
+    "response",
+    "response-context"
+  ),
+  createEntry(
+    "Server",
+    "Contains information about the software used by the origin server to handle the request.",
+    "response",
+    "response-context"
+  ),
+
+  // Range requests
+  createEntry(
+    "Accept-Ranges",
+    "Indicates if the server supports range requests, and if so in which unit the range can be expressed.",
+    "response",
+    "range-requests"
+  ),
+  createEntry("Range", "Indicates the part of a document that the server should return.", "request", "range-requests"),
+  createEntry(
+    "If-Range",
+    "Creates a conditional range request that is only fulfilled if the given etag or date matches the remote resource.",
+    "request",
+    "range-requests"
+  ),
+  createEntry(
+    "Content-Range",
+    "Indicates where in a full body message a partial message belongs.",
+    "response",
+    "range-requests"
+  ),
+
+  // Security
+  createEntry(
+    "Cross-Origin-Embedder-Policy",
+    "Allows a server to declare an embedder policy for a given document.",
+    "response",
+    "security"
+  ),
+  createEntry(
+    "Cross-Origin-Opener-Policy",
+    "Prevents other domains from opening/controlling a window.",
+    "response",
+    "security"
+  ),
+  createEntry(
+    "Cross-Origin-Resource-Policy",
+    "Prevents other domains from reading the response of the resources to which this header is applied.",
+    "response",
+    "security"
+  ),
+  createEntry(
+    "Content-Security-Policy",
+    "Controls resources the user agent is allowed to load for a given page.",
+    "response",
+    "security"
+  ),
+  createEntry(
+    "Content-Security-Policy-Report-Only",
+    "Allows web developers to experiment with policies by monitoring, but not enforcing, their effects.",
+    "response",
+    "security"
+  ),
+  createEntry(
+    "Permissions-Policy",
+    "Provides a mechanism to allow and deny the use of browser features in a website's own frame and in iframes that it embeds.",
+    "response",
+    "security"
+  ),
+  createEntry("Strict-Transport-Security", "Force communication using HTTPS instead of HTTP.", "response", "security"),
+  createEntry(
+    "Upgrade-Insecure-Requests",
+    "Sends a signal to the server expressing the client's preference for an encrypted and authenticated response.",
+    "request",
+    "security"
+  ),
+  createEntry(
+    "X-Content-Type-Options",
+    "Disables MIME sniffing and forces browser to use the type given in Content-Type.",
+    "response",
+    "security"
+  ),
+  createEntry(
+    "X-Frame-Options",
+    "Indicates whether a browser should be allowed to render a page in a frame, iframe, embed, or object.",
+    "response",
+    "security"
+  ),
+  createEntry(
+    "X-XSS-Protection",
+    "Enables cross-site scripting filtering. Deprecated in modern browsers.",
+    "response",
+    "security"
+  ),
+
+  // Transfer coding
+  createEntry(
+    "Transfer-Encoding",
+    "Specifies the form of encoding used to safely transfer the resource to the user.",
+    "response",
+    "transfer-coding"
+  ),
+  createEntry(
+    "TE",
+    "Specifies the transfer encodings the user agent is willing to accept.",
+    "request",
+    "transfer-coding"
+  ),
+  createEntry(
+    "Trailer",
+    "Allows the sender to include additional fields at the end of chunked messages.",
+    "both",
+    "transfer-coding"
+  ),
+
+  // WebSockets
+  createEntry("Sec-WebSocket-Accept", "The server's response to a WebSocket handshake.", "response", "websockets"),
+  createEntry("Sec-WebSocket-Extensions", "Specifies one or more WebSocket extensions to use.", "both", "websockets"),
+  createEntry(
+    "Sec-WebSocket-Key",
+    "A key used by the client to negotiate the WebSocket handshake.",
+    "request",
+    "websockets"
+  ),
+  createEntry("Sec-WebSocket-Protocol", "Specifies one or more WebSocket subprotocols.", "both", "websockets"),
+  createEntry(
+    "Sec-WebSocket-Version",
+    "Specifies the WebSocket protocol version the client wishes to use.",
+    "request",
+    "websockets"
+  ),
+
+  // Other
+  createEntry("Alt-Svc", "Used to list alternate ways to reach this service.", "response", "other"),
+  createEntry("Date", "Contains the date and time at which the message was originated.", "both", "other"),
+  createEntry(
+    "Link",
+    "This entity-header field provides a means for serializing one or more links in HTTP headers.",
+    "both",
+    "other"
+  ),
+  createEntry(
+    "Retry-After",
+    "Indicates how long the user agent should wait before making a follow-up request.",
+    "response",
+    "other"
+  ),
+  createEntry(
+    "Service-Worker-Allowed",
+    "Used to remove the path restriction of a service worker by including this header in the response of the service worker script.",
+    "response",
+    "other"
+  ),
+  createEntry(
+    "SourceMap",
+    "Links generated code to a source map, enabling the browser to reconstruct the original source.",
+    "response",
+    "other"
+  ),
+  createEntry(
+    "Upgrade",
+    "The standard mechanism for clients to request the server to use a different protocol.",
+    "both",
+    "other"
+  ),
+  createEntry(
+    "Priority",
+    "Provides a hint describing the priority of a particular resource request on a particular connection.",
+    "request",
+    "other"
+  ),
+];
+
+export const CATEGORY_LABELS: Record<HttpHeaderCategory, string> = {
+  authentication: "Authentication",
+  caching: "Caching",
+  conditionals: "Conditionals",
+  connection: "Connection",
+  "content-negotiation": "Content Negotiation",
+  controls: "Controls",
+  cookies: "Cookies",
+  cors: "CORS",
+  downloads: "Downloads",
+  "message-body": "Message Body",
+  proxies: "Proxies",
+  redirects: "Redirects",
+  "request-context": "Request Context",
+  "response-context": "Response Context",
+  "range-requests": "Range Requests",
+  security: "Security",
+  "transfer-coding": "Transfer Coding",
+  websockets: "WebSockets",
+  other: "Other",
+};
+
+export const TYPE_LABELS: Record<string, string> = {
+  request: "Request",
+  response: "Response",
+  both: "Both",
+};

--- a/src/screens/common-lists/http-headers/http-headers.store.ts
+++ b/src/screens/common-lists/http-headers/http-headers.store.ts
@@ -1,0 +1,50 @@
+import { create } from "zustand";
+import { createJSONStorage, devtools, persist } from "zustand/middleware";
+
+import type { HttpHeaderCategoryFilter, HttpHeaderTypeFilter } from "./http-headers.types";
+import { DEFAULT_CATEGORY, DEFAULT_FILTER, DEFAULT_PAGE, DEFAULT_PAGE_SIZE, DEFAULT_TYPE } from "./http-headers.utils";
+
+interface HttpHeadersState {
+  category: HttpHeaderCategoryFilter;
+  type: HttpHeaderTypeFilter;
+  filter: string;
+  page: number;
+  pageSize: number;
+  setCategory: (category: HttpHeaderCategoryFilter) => void;
+  setType: (type: HttpHeaderTypeFilter) => void;
+  setFilter: (filter: string) => void;
+  setPage: (page: number) => void;
+  setPageSize: (pageSize: number) => void;
+  resetFilters: () => void;
+}
+
+const stateCreator = (set: (partial: Partial<HttpHeadersState>) => void): HttpHeadersState => ({
+  category: DEFAULT_CATEGORY,
+  type: DEFAULT_TYPE,
+  filter: DEFAULT_FILTER,
+  page: DEFAULT_PAGE,
+  pageSize: DEFAULT_PAGE_SIZE,
+  setCategory: (category) => set({ category, page: DEFAULT_PAGE }),
+  setType: (type) => set({ type, page: DEFAULT_PAGE }),
+  setFilter: (filter) => set({ filter, page: DEFAULT_PAGE }),
+  setPage: (page) => set({ page }),
+  setPageSize: (pageSize) => set({ pageSize, page: DEFAULT_PAGE }),
+  resetFilters: () =>
+    set({
+      category: DEFAULT_CATEGORY,
+      type: DEFAULT_TYPE,
+      filter: DEFAULT_FILTER,
+      page: DEFAULT_PAGE,
+    }),
+});
+
+const PERSISTED_STORE_NAME = "etoolbox-http-headers";
+
+const persistedStateCreator = persist<HttpHeadersState>(stateCreator, {
+  name: PERSISTED_STORE_NAME,
+  storage: createJSONStorage(() => localStorage),
+});
+
+export const useHttpHeadersStore = create<HttpHeadersState>()(
+  devtools(persistedStateCreator, { name: PERSISTED_STORE_NAME })
+);

--- a/src/screens/common-lists/http-headers/http-headers.tsx
+++ b/src/screens/common-lists/http-headers/http-headers.tsx
@@ -1,0 +1,34 @@
+import { GlobalOutlined } from "@ant-design/icons";
+import { Flex } from "antd";
+import { createStyles } from "antd-style";
+
+import { ScreenContainer } from "~/components/ui/screen-container";
+import { ScreenHeader } from "~/components/ui/screen-header";
+
+import { HttpHeadersTable } from "./http-headers-table";
+import { HttpHeadersToolbar } from "./http-headers-toolbar";
+
+export const HttpHeaders = () => {
+  const { styles } = useStyles();
+
+  return (
+    <ScreenContainer>
+      <Flex vertical gap="small" className={styles.container}>
+        <ScreenHeader
+          icon={<GlobalOutlined />}
+          title="HTTP Headers"
+          description="Browse and search through all standard HTTP headers with their official descriptions from MDN Web Docs"
+        />
+
+        <HttpHeadersToolbar />
+        <HttpHeadersTable />
+      </Flex>
+    </ScreenContainer>
+  );
+};
+
+const useStyles = createStyles(() => ({
+  container: {
+    width: "100%",
+  },
+}));

--- a/src/screens/common-lists/http-headers/http-headers.types.ts
+++ b/src/screens/common-lists/http-headers/http-headers.types.ts
@@ -1,0 +1,34 @@
+export interface HttpHeaderEntry {
+  name: string;
+  description: string;
+  type: HttpHeaderType;
+  category: HttpHeaderCategory;
+  mdnUrl: string;
+}
+
+export type HttpHeaderType = "request" | "response" | "both";
+
+export type HttpHeaderCategory =
+  | "authentication"
+  | "caching"
+  | "conditionals"
+  | "connection"
+  | "content-negotiation"
+  | "controls"
+  | "cookies"
+  | "cors"
+  | "downloads"
+  | "message-body"
+  | "proxies"
+  | "redirects"
+  | "request-context"
+  | "response-context"
+  | "range-requests"
+  | "security"
+  | "transfer-coding"
+  | "websockets"
+  | "other";
+
+export type HttpHeaderCategoryFilter = "all" | HttpHeaderCategory;
+
+export type HttpHeaderTypeFilter = "all" | HttpHeaderType;

--- a/src/screens/common-lists/http-headers/http-headers.utils.ts
+++ b/src/screens/common-lists/http-headers/http-headers.utils.ts
@@ -1,0 +1,82 @@
+import { CATEGORY_LABELS, HTTP_HEADERS } from "./http-headers.constants";
+import type {
+  HttpHeaderEntry,
+  HttpHeaderCategoryFilter,
+  HttpHeaderTypeFilter,
+  HttpHeaderCategory,
+} from "./http-headers.types";
+
+export const CATEGORIES: HttpHeaderCategory[] = [
+  "authentication",
+  "caching",
+  "conditionals",
+  "connection",
+  "content-negotiation",
+  "controls",
+  "cookies",
+  "cors",
+  "downloads",
+  "message-body",
+  "proxies",
+  "redirects",
+  "request-context",
+  "response-context",
+  "range-requests",
+  "security",
+  "transfer-coding",
+  "websockets",
+  "other",
+];
+
+export const CATEGORY_OPTIONS = [
+  { value: "all" as const, label: "All categories" },
+  ...CATEGORIES.map((category) => ({
+    value: category,
+    label: CATEGORY_LABELS[category] ?? category,
+  })),
+];
+
+export const TYPE_OPTIONS = [
+  { value: "all" as const, label: "All types" },
+  { value: "request" as const, label: "Request" },
+  { value: "response" as const, label: "Response" },
+  { value: "both" as const, label: "Both" },
+];
+
+interface ApplyFilteringArgs {
+  category: HttpHeaderCategoryFilter;
+  type: HttpHeaderTypeFilter;
+  filter: string;
+}
+
+export const applyFiltering = ({ category, type, filter }: ApplyFilteringArgs): HttpHeaderEntry[] => {
+  let results = HTTP_HEADERS.slice();
+
+  if (category && category !== "all") {
+    results = results.filter((entry) => entry.category === category);
+  }
+
+  if (type && type !== "all") {
+    results = results.filter((entry) => entry.type === type || entry.type === "both");
+  }
+
+  if (filter) {
+    const filterLowercase = filter.toLowerCase();
+
+    results = results.filter((entry) => {
+      return (
+        entry.name.toLowerCase().includes(filterLowercase) || entry.description.toLowerCase().includes(filterLowercase)
+      );
+    });
+  }
+
+  return results;
+};
+
+export const DEFAULT_CATEGORY: HttpHeaderCategoryFilter = "all";
+export const DEFAULT_TYPE: HttpHeaderTypeFilter = "all";
+export const DEFAULT_FILTER = "";
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_PAGE_SIZE = 200;
+
+export const PAGE_SIZE_OPTIONS = [10, 25, 50, 100, 200];

--- a/src/screens/common-lists/http-headers/use-http-headers-columns.tsx
+++ b/src/screens/common-lists/http-headers/use-http-headers-columns.tsx
@@ -1,0 +1,131 @@
+import { LinkOutlined } from "@ant-design/icons";
+import { Tag, Tooltip, Typography } from "antd";
+import type { ColumnsType } from "antd/es/table";
+import { createStyles } from "antd-style";
+
+import { useResponsive } from "~/hooks/use-responsive";
+
+import { CATEGORY_LABELS, TYPE_LABELS } from "./http-headers.constants";
+import type { HttpHeaderEntry } from "./http-headers.types";
+
+const { Text } = Typography;
+
+const CATEGORY_COLORS: Record<string, string> = {
+  authentication: "purple",
+  caching: "blue",
+  conditionals: "cyan",
+  connection: "geekblue",
+  "content-negotiation": "lime",
+  controls: "gold",
+  cookies: "orange",
+  cors: "volcano",
+  downloads: "magenta",
+  "message-body": "green",
+  proxies: "blue",
+  redirects: "orange",
+  "request-context": "cyan",
+  "response-context": "geekblue",
+  "range-requests": "purple",
+  security: "red",
+  "transfer-coding": "gold",
+  websockets: "lime",
+  other: "default",
+};
+
+const TYPE_COLORS: Record<string, string> = {
+  request: "blue",
+  response: "green",
+  both: "purple",
+};
+
+export const useHttpHeadersColumns = (): ColumnsType<HttpHeaderEntry> => {
+  const { styles } = useStyles();
+  const { isMobile } = useResponsive();
+
+  return [
+    {
+      title: "Header",
+      dataIndex: "name",
+      key: "name",
+      width: isMobile ? 180 : 280,
+      sorter: (a, b) => a.name.localeCompare(b.name),
+      render: (name: string, record: HttpHeaderEntry) => (
+        <div className={styles.nameCell}>
+          <div className={styles.nameRow}>
+            <Text strong className={styles.nameText}>
+              {name}
+            </Text>
+            <Tooltip title="View on MDN">
+              <a href={record.mdnUrl} target="_blank" rel="noopener noreferrer" className={styles.mdnLink}>
+                <LinkOutlined />
+              </a>
+            </Tooltip>
+          </div>
+          <div className={styles.tagsRow}>
+            <Tag color={TYPE_COLORS[record.type] ?? "default"} className={styles.typeTag}>
+              {TYPE_LABELS[record.type] ?? record.type}
+            </Tag>
+            <Tag color={CATEGORY_COLORS[record.category] ?? "default"} className={styles.categoryTag}>
+              {CATEGORY_LABELS[record.category] ?? record.category}
+            </Tag>
+          </div>
+        </div>
+      ),
+    },
+    {
+      title: "Description",
+      dataIndex: "description",
+      key: "description",
+      render: (description: string) => <Text className={styles.description}>{description}</Text>,
+    },
+  ];
+};
+
+const useStyles = createStyles(({ token }) => ({
+  nameCell: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    gap: 4,
+  },
+  nameRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+  },
+  tagsRow: {
+    display: "flex",
+    gap: 4,
+    flexWrap: "wrap",
+  },
+  nameText: {
+    fontSize: 13,
+    fontFamily: "monospace",
+    color: token.colorPrimary,
+  },
+  mdnLink: {
+    color: token.colorTextSecondary,
+    fontSize: 14,
+    "&:hover": {
+      color: token.colorPrimary,
+    },
+  },
+  typeTag: {
+    fontSize: 10,
+    marginRight: 0,
+    padding: "0 4px",
+  },
+  categoryTag: {
+    fontSize: 10,
+    marginRight: 0,
+    padding: "0 4px",
+  },
+  description: {
+    margin: "0 !important",
+    fontSize: 12,
+    color: token.colorTextSecondary,
+    lineHeight: 1.6,
+    whiteSpace: "normal",
+    wordBreak: "break-word",
+  },
+}));


### PR DESCRIPTION
## Changes Description

- Add new HTTP Headers reference screen under Common Lists
- Searchable table with 100+ standard HTTP headers
- Includes official descriptions from MDN Web Docs
- Features: search, filter by category, copy header name

## Checklist

- [x] code follows project [coding guidelines](https://github.com/amwebexpert/chrome-extensions-collection/blob/master/packages/coding-guide-helper/public/markdowns/table-of-content.md).
- [x] documentation has been updated (if applicable).
- [ ] tests have been added or updated (if applicable).
- [ ] e2e tests completed

## Screen capture(s) or recording

<img width="3010" height="1714" alt="image" src="https://github.com/user-attachments/assets/f18e9959-9d35-412e-9f72-a3f7cb4fe0b5" />
