### PR TITLE
refactor: improve DRY for all paginated filtered lists

### DIFF
--- a/src/screens/colors/named/named-colors-table.tsx
+++ b/src/screens/colors/named/named-colors-table.tsx
@@ -1,31 +1,23 @@
 import { Table } from "antd";
 import { createStyles } from "antd-style";
-import { useDeferredValue } from "react";
 
 import { useResponsive } from "~/hooks/use-responsive";
 
 import { useNamedColorsStore } from "./named-colors.store";
-import { applyFiltering, PAGE_SIZE_OPTIONS } from "./named-colors.utils";
+import type { ColorInfo } from "./named-colors.utils";
+import { PAGE_SIZE_OPTIONS } from "./named-colors.utils";
 import { useNamedColorsColumns } from "./use-named-colors-columns";
 
-export const NamedColorsTable = () => {
+interface NamedColorsTableProps {
+  filteredColors: ColorInfo[];
+}
+
+export const NamedColorsTable = ({ filteredColors }: NamedColorsTableProps) => {
   const { styles } = useStyles();
   const { isMobile } = useResponsive();
   const columns = useNamedColorsColumns();
 
-  const { family, filter, page, pageSize, setPage, setPageSize } = useNamedColorsStore();
-
-  const deferredFamily = useDeferredValue(family);
-  const deferredFilter = useDeferredValue(filter);
-
-  const filteredColors = applyFiltering({ family: deferredFamily, filter: deferredFilter });
-
-  const handlePageChange = (newPage: number, newPageSize: number) => {
-    setPage(newPage);
-    if (newPageSize !== pageSize) {
-      setPageSize(newPageSize);
-    }
-  };
+  const { page, pageSize, handlePageChange } = useNamedColorsStore();
 
   return (
     <Table

--- a/src/screens/colors/named/named-colors-toolbar.tsx
+++ b/src/screens/colors/named/named-colors-toolbar.tsx
@@ -11,9 +11,7 @@ export const NamedColorsToolbar = () => {
   const { styles } = useStyles();
   const { isDesktop } = useResponsive();
 
-  const { family, filter, setFamily, setFilter, resetFilters } = useNamedColorsStore();
-
-  const hasFilters = family !== "all" || filter !== "";
+  const { family, filter, setFamily, setFilter, hasFilters, resetFilters } = useNamedColorsStore();
 
   const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFilter(e.target.value);
@@ -45,11 +43,9 @@ export const NamedColorsToolbar = () => {
 
       <Col xs={24} sm={24} md={8} lg={12}>
         <Space className={styles.actions}>
-          {hasFilters && (
-            <Button icon={<ClearOutlined />} onClick={resetFilters}>
-              Clear filters
-            </Button>
-          )}
+          <Button icon={<ClearOutlined />} onClick={resetFilters} disabled={!hasFilters()}>
+            Clear filters
+          </Button>
         </Space>
       </Col>
     </Row>

--- a/src/screens/colors/named/named-colors.store.ts
+++ b/src/screens/colors/named/named-colors.store.ts
@@ -10,20 +10,30 @@ interface NamedColorsState {
   pageSize: number;
   setFamily: (family: string) => void;
   setFilter: (filter: string) => void;
-  setPage: (page: number) => void;
-  setPageSize: (pageSize: number) => void;
+  handlePageChange: (page: number, pageSize: number) => void;
+  hasFilters: () => boolean;
   resetFilters: () => void;
 }
 
-const stateCreator = (set: (partial: Partial<NamedColorsState>) => void): NamedColorsState => ({
+const stateCreator = (
+  set: (partial: Partial<NamedColorsState>) => void,
+  get: () => NamedColorsState
+): NamedColorsState => ({
   family: DEFAULT_FAMILY,
   filter: DEFAULT_FILTER,
   page: DEFAULT_PAGE,
   pageSize: DEFAULT_PAGE_SIZE,
   setFamily: (family) => set({ family, page: DEFAULT_PAGE }),
   setFilter: (filter) => set({ filter, page: DEFAULT_PAGE }),
-  setPage: (page) => set({ page }),
-  setPageSize: (pageSize) => set({ pageSize, page: DEFAULT_PAGE }),
+  handlePageChange: (page, pageSize) => {
+    const currentPageSize = get().pageSize;
+    if (pageSize !== currentPageSize) {
+      set({ page: DEFAULT_PAGE, pageSize });
+    } else {
+      set({ page });
+    }
+  },
+  hasFilters: () => get().family !== DEFAULT_FAMILY || get().filter !== DEFAULT_FILTER,
   resetFilters: () =>
     set({
       family: DEFAULT_FAMILY,

--- a/src/screens/colors/named/named-colors.tsx
+++ b/src/screens/colors/named/named-colors.tsx
@@ -1,15 +1,25 @@
 import { BgColorsOutlined } from "@ant-design/icons";
 import { Flex } from "antd";
 import { createStyles } from "antd-style";
+import { useDeferredValue } from "react";
 
 import { ScreenContainer } from "~/components/ui/screen-container";
 import { ScreenHeader } from "~/components/ui/screen-header";
 
+import { useNamedColorsStore } from "./named-colors.store";
 import { NamedColorsTable } from "./named-colors-table";
 import { NamedColorsToolbar } from "./named-colors-toolbar";
+import { applyFiltering } from "./named-colors.utils";
 
 export const NamedColors = () => {
   const { styles } = useStyles();
+
+  const { family, filter } = useNamedColorsStore();
+
+  const deferredFamily = useDeferredValue(family);
+  const deferredFilter = useDeferredValue(filter);
+
+  const filteredColors = applyFiltering({ family: deferredFamily, filter: deferredFilter });
 
   return (
     <ScreenContainer>
@@ -21,7 +31,7 @@ export const NamedColors = () => {
         />
 
         <NamedColorsToolbar />
-        <NamedColorsTable />
+        <NamedColorsTable filteredColors={filteredColors} />
       </Flex>
     </ScreenContainer>
   );

--- a/src/screens/common-lists/html-entities/html-entities-table.tsx
+++ b/src/screens/common-lists/html-entities/html-entities-table.tsx
@@ -1,37 +1,24 @@
 import { Table } from "antd";
 import { createStyles } from "antd-style";
-import { useDeferredValue } from "react";
 
 import { useResponsive } from "~/hooks/use-responsive";
 
 import { PAGE_SIZE_OPTIONS } from "./html-entities.constants";
 import { useHtmlEntitiesStore } from "./html-entities.store";
-import { applyFiltering, getEntityUniqueKey } from "./html-entities.utils";
+import type { HtmlEntity } from "./html-entities.types";
+import { getEntityUniqueKey } from "./html-entities.utils";
 import { useHtmlEntitiesColumns } from "./use-html-entities-columns";
 
-export const HtmlEntitiesTable = () => {
+interface HtmlEntitiesTableProps {
+  filteredEntities: HtmlEntity[];
+}
+
+export const HtmlEntitiesTable = ({ filteredEntities }: HtmlEntitiesTableProps) => {
   const { styles } = useStyles();
   const { isMobile } = useResponsive();
   const columns = useHtmlEntitiesColumns();
 
-  const { category, filter, filterField, page, pageSize, setPage, setPageSize } = useHtmlEntitiesStore();
-
-  const deferredCategory = useDeferredValue(category);
-  const deferredFilter = useDeferredValue(filter);
-  const deferredFilterField = useDeferredValue(filterField);
-
-  const filteredEntities = applyFiltering({
-    category: deferredCategory,
-    filter: deferredFilter,
-    filterField: deferredFilterField,
-  });
-
-  const handlePageChange = (newPage: number, newPageSize: number) => {
-    setPage(newPage);
-    if (newPageSize !== pageSize) {
-      setPageSize(newPageSize);
-    }
-  };
+  const { page, pageSize, handlePageChange } = useHtmlEntitiesStore();
 
   return (
     <Table

--- a/src/screens/common-lists/html-entities/html-entities-toolbar.tsx
+++ b/src/screens/common-lists/html-entities/html-entities-toolbar.tsx
@@ -1,35 +1,25 @@
 import { ClearOutlined, SearchOutlined } from "@ant-design/icons";
 import { Button, Col, Input, Row, Select, Space, Typography } from "antd";
 import { createStyles } from "antd-style";
-import { useDeferredValue } from "react";
 
 import { useResponsive } from "~/hooks/use-responsive";
 
 import { CATEGORY_OPTIONS, FILTER_FIELD_OPTIONS, HTML_ENTITIES } from "./html-entities.constants";
 import { useHtmlEntitiesStore } from "./html-entities.store";
 import type { HtmlEntityCategory, HtmlEntityFilterField } from "./html-entities.types";
-import { applyFiltering, DEFAULT_CATEGORY, DEFAULT_FILTER_FIELD } from "./html-entities.utils";
 
 const { Text } = Typography;
 
-export const HtmlEntitiesToolbar = () => {
+interface HtmlEntitiesToolbarProps {
+  filteredCount: number;
+}
+
+export const HtmlEntitiesToolbar = ({ filteredCount }: HtmlEntitiesToolbarProps) => {
   const { styles } = useStyles();
   const { isDesktop } = useResponsive();
 
-  const { category, filter, filterField, setCategory, setFilter, setFilterField, resetFilters } =
+  const { category, filter, filterField, setCategory, setFilter, setFilterField, hasFilters, resetFilters } =
     useHtmlEntitiesStore();
-
-  const deferredCategory = useDeferredValue(category);
-  const deferredFilter = useDeferredValue(filter);
-  const deferredFilterField = useDeferredValue(filterField);
-
-  const filteredCount = applyFiltering({
-    category: deferredCategory,
-    filter: deferredFilter,
-    filterField: deferredFilterField,
-  }).length;
-
-  const hasFilters = category !== DEFAULT_CATEGORY || filter !== "" || filterField !== DEFAULT_FILTER_FIELD;
 
   const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFilter(e.target.value);
@@ -85,11 +75,9 @@ export const HtmlEntitiesToolbar = () => {
 
       <Col xs={12} sm={6} md={4} lg={8}>
         <Space className={styles.actions}>
-          {hasFilters && (
-            <Button icon={<ClearOutlined />} onClick={resetFilters}>
-              Clear
-            </Button>
-          )}
+          <Button icon={<ClearOutlined />} onClick={resetFilters} disabled={!hasFilters()}>
+            Clear
+          </Button>
         </Space>
       </Col>
     </Row>

--- a/src/screens/common-lists/html-entities/html-entities.constants.ts
+++ b/src/screens/common-lists/html-entities/html-entities.constants.ts
@@ -634,4 +634,4 @@ export const FILTER_FIELD_OPTIONS: { value: HtmlEntityFilterField; label: string
   { value: "named-only", label: "Named only" },
 ];
 
-export const PAGE_SIZE_OPTIONS = [10, 25, 50, 100, 200];
+export const PAGE_SIZE_OPTIONS = [5, 10, 25, 50, 100, 200];

--- a/src/screens/common-lists/html-entities/html-entities.store.ts
+++ b/src/screens/common-lists/html-entities/html-entities.store.ts
@@ -19,12 +19,15 @@ interface HtmlEntitiesState {
   setCategory: (category: HtmlEntityCategory) => void;
   setFilter: (filter: string) => void;
   setFilterField: (filterField: HtmlEntityFilterField) => void;
-  setPage: (page: number) => void;
-  setPageSize: (pageSize: number) => void;
+  handlePageChange: (page: number, pageSize: number) => void;
+  hasFilters: () => boolean;
   resetFilters: () => void;
 }
 
-const stateCreator = (set: (partial: Partial<HtmlEntitiesState>) => void): HtmlEntitiesState => ({
+const stateCreator = (
+  set: (partial: Partial<HtmlEntitiesState>) => void,
+  get: () => HtmlEntitiesState
+): HtmlEntitiesState => ({
   category: DEFAULT_CATEGORY,
   filter: DEFAULT_FILTER,
   filterField: DEFAULT_FILTER_FIELD,
@@ -33,8 +36,18 @@ const stateCreator = (set: (partial: Partial<HtmlEntitiesState>) => void): HtmlE
   setCategory: (category) => set({ category, page: DEFAULT_PAGE }),
   setFilter: (filter) => set({ filter, page: DEFAULT_PAGE }),
   setFilterField: (filterField) => set({ filterField, page: DEFAULT_PAGE }),
-  setPage: (page) => set({ page }),
-  setPageSize: (pageSize) => set({ pageSize, page: DEFAULT_PAGE }),
+  handlePageChange: (page, pageSize) => {
+    const currentPageSize = get().pageSize;
+    if (pageSize !== currentPageSize) {
+      set({ page: DEFAULT_PAGE, pageSize });
+    } else {
+      set({ page });
+    }
+  },
+  hasFilters: () =>
+    get().category !== DEFAULT_CATEGORY ||
+    get().filter !== DEFAULT_FILTER ||
+    get().filterField !== DEFAULT_FILTER_FIELD,
   resetFilters: () =>
     set({
       category: DEFAULT_CATEGORY,

--- a/src/screens/common-lists/html-entities/html-entities.tsx
+++ b/src/screens/common-lists/html-entities/html-entities.tsx
@@ -1,15 +1,30 @@
 import { CodeOutlined } from "@ant-design/icons";
 import { Flex } from "antd";
 import { createStyles } from "antd-style";
+import { useDeferredValue } from "react";
 
 import { ScreenContainer } from "~/components/ui/screen-container";
 import { ScreenHeader } from "~/components/ui/screen-header";
 
+import { useHtmlEntitiesStore } from "./html-entities.store";
 import { HtmlEntitiesTable } from "./html-entities-table";
 import { HtmlEntitiesToolbar } from "./html-entities-toolbar";
+import { applyFiltering } from "./html-entities.utils";
 
 export const HtmlEntities = () => {
   const { styles } = useStyles();
+
+  const { category, filter, filterField } = useHtmlEntitiesStore();
+
+  const deferredCategory = useDeferredValue(category);
+  const deferredFilter = useDeferredValue(filter);
+  const deferredFilterField = useDeferredValue(filterField);
+
+  const filteredEntities = applyFiltering({
+    category: deferredCategory,
+    filter: deferredFilter,
+    filterField: deferredFilterField,
+  });
 
   return (
     <ScreenContainer>
@@ -20,8 +35,8 @@ export const HtmlEntities = () => {
           description="Browse and search through HTML character entities with their codes, names, and Unicode values"
         />
 
-        <HtmlEntitiesToolbar />
-        <HtmlEntitiesTable />
+        <HtmlEntitiesToolbar filteredCount={filteredEntities.length} />
+        <HtmlEntitiesTable filteredEntities={filteredEntities} />
       </Flex>
     </ScreenContainer>
   );

--- a/src/screens/common-lists/http-headers/http-headers-table.tsx
+++ b/src/screens/common-lists/http-headers/http-headers-table.tsx
@@ -1,32 +1,23 @@
 import { Table } from "antd";
 import { createStyles } from "antd-style";
-import { useDeferredValue } from "react";
 
 import { useResponsive } from "~/hooks/use-responsive";
 
 import { useHttpHeadersStore } from "./http-headers.store";
-import { applyFiltering, PAGE_SIZE_OPTIONS } from "./http-headers.utils";
+import type { HttpHeaderEntry } from "./http-headers.types";
+import { PAGE_SIZE_OPTIONS } from "./http-headers.utils";
 import { useHttpHeadersColumns } from "./use-http-headers-columns";
 
-export const HttpHeadersTable = () => {
+interface HttpHeadersTableProps {
+  filteredHeaders: HttpHeaderEntry[];
+}
+
+export const HttpHeadersTable = ({ filteredHeaders }: HttpHeadersTableProps) => {
   const { styles } = useStyles();
   const { isMobile } = useResponsive();
   const columns = useHttpHeadersColumns();
 
-  const { category, type, filter, page, pageSize, setPage, setPageSize } = useHttpHeadersStore();
-
-  const deferredCategory = useDeferredValue(category);
-  const deferredType = useDeferredValue(type);
-  const deferredFilter = useDeferredValue(filter);
-
-  const filteredHeaders = applyFiltering({ category: deferredCategory, type: deferredType, filter: deferredFilter });
-
-  const handlePageChange = (newPage: number, newPageSize: number) => {
-    setPage(newPage);
-    if (newPageSize !== pageSize) {
-      setPageSize(newPageSize);
-    }
-  };
+  const { page, pageSize, handlePageChange } = useHttpHeadersStore();
 
   return (
     <Table

--- a/src/screens/common-lists/http-headers/http-headers-toolbar.tsx
+++ b/src/screens/common-lists/http-headers/http-headers-toolbar.tsx
@@ -1,32 +1,24 @@
 import { ClearOutlined, SearchOutlined } from "@ant-design/icons";
 import { Button, Col, Input, Row, Select, Space, Typography } from "antd";
 import { createStyles } from "antd-style";
-import { useDeferredValue } from "react";
 
 import { useResponsive } from "~/hooks/use-responsive";
 
 import { HTTP_HEADERS } from "./http-headers.constants";
 import { useHttpHeadersStore } from "./http-headers.store";
-import { applyFiltering, CATEGORY_OPTIONS, DEFAULT_CATEGORY, DEFAULT_TYPE, TYPE_OPTIONS } from "./http-headers.utils";
+import { CATEGORY_OPTIONS, TYPE_OPTIONS } from "./http-headers.utils";
 
 const { Text } = Typography;
 
-export const HttpHeadersToolbar = () => {
+interface HttpHeadersToolbarProps {
+  filteredCount: number;
+}
+
+export const HttpHeadersToolbar = ({ filteredCount }: HttpHeadersToolbarProps) => {
   const { styles } = useStyles();
   const { isDesktop } = useResponsive();
 
-  const { category, type, filter, setCategory, setType, setFilter, resetFilters } = useHttpHeadersStore();
-
-  const deferredCategory = useDeferredValue(category);
-  const deferredType = useDeferredValue(type);
-  const deferredFilter = useDeferredValue(filter);
-  const filteredCount = applyFiltering({
-    category: deferredCategory,
-    type: deferredType,
-    filter: deferredFilter,
-  }).length;
-
-  const hasFilters = category !== DEFAULT_CATEGORY || type !== DEFAULT_TYPE || filter !== "";
+  const { category, type, filter, hasFilters, setCategory, setType, setFilter, resetFilters } = useHttpHeadersStore();
 
   const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFilter(e.target.value);
@@ -74,11 +66,9 @@ export const HttpHeadersToolbar = () => {
 
       <Col xs={12} sm={6} md={4} lg={8}>
         <Space className={styles.actions}>
-          {hasFilters && (
-            <Button icon={<ClearOutlined />} onClick={resetFilters}>
-              Clear filters
-            </Button>
-          )}
+          <Button icon={<ClearOutlined />} onClick={resetFilters} disabled={!hasFilters()}>
+            Clear filters
+          </Button>
         </Space>
       </Col>
     </Row>

--- a/src/screens/common-lists/http-headers/http-headers.store.ts
+++ b/src/screens/common-lists/http-headers/http-headers.store.ts
@@ -10,25 +10,36 @@ interface HttpHeadersState {
   filter: string;
   page: number;
   pageSize: number;
+  hasFilters: () => boolean;
   setCategory: (category: HttpHeaderCategoryFilter) => void;
   setType: (type: HttpHeaderTypeFilter) => void;
   setFilter: (filter: string) => void;
-  setPage: (page: number) => void;
-  setPageSize: (pageSize: number) => void;
+  handlePageChange: (page: number, pageSize: number) => void;
   resetFilters: () => void;
 }
 
-const stateCreator = (set: (partial: Partial<HttpHeadersState>) => void): HttpHeadersState => ({
+const stateCreator = (
+  set: (partial: Partial<HttpHeadersState>) => void,
+  get: () => HttpHeadersState
+): HttpHeadersState => ({
   category: DEFAULT_CATEGORY,
   type: DEFAULT_TYPE,
   filter: DEFAULT_FILTER,
   page: DEFAULT_PAGE,
   pageSize: DEFAULT_PAGE_SIZE,
+  hasFilters: () =>
+    get().category !== DEFAULT_CATEGORY || get().type !== DEFAULT_TYPE || get().filter !== DEFAULT_FILTER,
   setCategory: (category) => set({ category, page: DEFAULT_PAGE }),
   setType: (type) => set({ type, page: DEFAULT_PAGE }),
   setFilter: (filter) => set({ filter, page: DEFAULT_PAGE }),
-  setPage: (page) => set({ page }),
-  setPageSize: (pageSize) => set({ pageSize, page: DEFAULT_PAGE }),
+  handlePageChange: (page, pageSize) => {
+    const currentPageSize = get().pageSize;
+    if (pageSize !== currentPageSize) {
+      set({ page: DEFAULT_PAGE, pageSize });
+    } else {
+      set({ page });
+    }
+  },
   resetFilters: () =>
     set({
       category: DEFAULT_CATEGORY,

--- a/src/screens/common-lists/http-headers/http-headers.tsx
+++ b/src/screens/common-lists/http-headers/http-headers.tsx
@@ -1,15 +1,29 @@
 import { GlobalOutlined } from "@ant-design/icons";
 import { Flex } from "antd";
 import { createStyles } from "antd-style";
+import { useDeferredValue } from "react";
 
 import { ScreenContainer } from "~/components/ui/screen-container";
 import { ScreenHeader } from "~/components/ui/screen-header";
 
 import { HttpHeadersTable } from "./http-headers-table";
 import { HttpHeadersToolbar } from "./http-headers-toolbar";
+import { useHttpHeadersStore } from "./http-headers.store";
+import { applyFiltering } from "./http-headers.utils";
 
 export const HttpHeaders = () => {
   const { styles } = useStyles();
+
+  const { category, type, filter } = useHttpHeadersStore();
+  const deferredCategory = useDeferredValue(category);
+  const deferredType = useDeferredValue(type);
+  const deferredFilter = useDeferredValue(filter);
+
+  const filteredHeaders = applyFiltering({
+    category: deferredCategory,
+    type: deferredType,
+    filter: deferredFilter,
+  });
 
   return (
     <ScreenContainer>
@@ -20,8 +34,8 @@ export const HttpHeaders = () => {
           description="Browse and search through all standard HTTP headers with their official descriptions from MDN Web Docs"
         />
 
-        <HttpHeadersToolbar />
-        <HttpHeadersTable />
+        <HttpHeadersToolbar filteredCount={filteredHeaders.length} />
+        <HttpHeadersTable filteredHeaders={filteredHeaders} />
       </Flex>
     </ScreenContainer>
   );

--- a/src/screens/common-lists/http-headers/http-headers.utils.ts
+++ b/src/screens/common-lists/http-headers/http-headers.utils.ts
@@ -79,4 +79,4 @@ export const DEFAULT_FILTER = "";
 export const DEFAULT_PAGE = 1;
 export const DEFAULT_PAGE_SIZE = 200;
 
-export const PAGE_SIZE_OPTIONS = [10, 25, 50, 100, 200];
+export const PAGE_SIZE_OPTIONS = [5, 10, 25, 50, 100, 200];

--- a/src/screens/common-lists/http-status-codes/http-status-codes-table.tsx
+++ b/src/screens/common-lists/http-status-codes/http-status-codes-table.tsx
@@ -1,31 +1,23 @@
 import { Table } from "antd";
 import { createStyles } from "antd-style";
-import { useDeferredValue } from "react";
 
 import { useResponsive } from "~/hooks/use-responsive";
 
 import { useHttpStatusCodesStore } from "./http-status-codes.store";
-import { applyFiltering, PAGE_SIZE_OPTIONS } from "./http-status-codes.utils";
+import type { HttpStatusCodeEntry } from "./http-status-codes.types";
+import { PAGE_SIZE_OPTIONS } from "./http-status-codes.utils";
 import { useHttpStatusCodesColumns } from "./use-http-status-codes-columns";
 
-export const HttpStatusCodesTable = () => {
+interface HttpStatusCodesTableProps {
+  filteredStatusCodes: HttpStatusCodeEntry[];
+}
+
+export const HttpStatusCodesTable = ({ filteredStatusCodes }: HttpStatusCodesTableProps) => {
   const { styles } = useStyles();
   const { isMobile } = useResponsive();
   const columns = useHttpStatusCodesColumns();
 
-  const { category, filter, page, pageSize, setPage, setPageSize } = useHttpStatusCodesStore();
-
-  const deferredCategory = useDeferredValue(category);
-  const deferredFilter = useDeferredValue(filter);
-
-  const filteredStatusCodes = applyFiltering({ category: deferredCategory, filter: deferredFilter });
-
-  const handlePageChange = (newPage: number, newPageSize: number) => {
-    setPage(newPage);
-    if (newPageSize !== pageSize) {
-      setPageSize(newPageSize);
-    }
-  };
+  const { page, pageSize, handlePageChange } = useHttpStatusCodesStore();
 
   return (
     <Table

--- a/src/screens/common-lists/http-status-codes/http-status-codes-toolbar.tsx
+++ b/src/screens/common-lists/http-status-codes/http-status-codes-toolbar.tsx
@@ -1,27 +1,24 @@
 import { ClearOutlined, SearchOutlined } from "@ant-design/icons";
 import { Button, Col, Input, Row, Select, Space, Typography } from "antd";
 import { createStyles } from "antd-style";
-import { useDeferredValue } from "react";
 
 import { useResponsive } from "~/hooks/use-responsive";
 
 import { HTTP_STATUS_CODES } from "./http-status-codes.constants";
 import { useHttpStatusCodesStore } from "./http-status-codes.store";
-import { applyFiltering, CATEGORY_OPTIONS, DEFAULT_CATEGORY } from "./http-status-codes.utils";
+import { CATEGORY_OPTIONS } from "./http-status-codes.utils";
 
 const { Text } = Typography;
 
-export const HttpStatusCodesToolbar = () => {
+interface HttpStatusCodesToolbarProps {
+  filteredCount: number;
+}
+
+export const HttpStatusCodesToolbar = ({ filteredCount }: HttpStatusCodesToolbarProps) => {
   const { styles } = useStyles();
   const { isDesktop } = useResponsive();
 
-  const { category, filter, setCategory, setFilter, resetFilters } = useHttpStatusCodesStore();
-
-  const deferredCategory = useDeferredValue(category);
-  const deferredFilter = useDeferredValue(filter);
-  const filteredCount = applyFiltering({ category: deferredCategory, filter: deferredFilter }).length;
-
-  const hasFilters = category !== DEFAULT_CATEGORY || filter !== "";
+  const { category, filter, hasFilters, setCategory, setFilter, resetFilters } = useHttpStatusCodesStore();
 
   const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFilter(e.target.value);
@@ -59,11 +56,9 @@ export const HttpStatusCodesToolbar = () => {
 
       <Col xs={12} sm={12} md={6} lg={8}>
         <Space className={styles.actions}>
-          {hasFilters && (
-            <Button icon={<ClearOutlined />} onClick={resetFilters}>
-              Clear filters
-            </Button>
-          )}
+          <Button icon={<ClearOutlined />} onClick={resetFilters} disabled={!hasFilters()}>
+            Clear filters
+          </Button>
         </Space>
       </Col>
     </Row>

--- a/src/screens/common-lists/http-status-codes/http-status-codes.store.ts
+++ b/src/screens/common-lists/http-status-codes/http-status-codes.store.ts
@@ -9,22 +9,32 @@ interface HttpStatusCodesState {
   filter: string;
   page: number;
   pageSize: number;
+  hasFilters: () => boolean;
   setCategory: (category: HttpStatusCategoryFilter) => void;
   setFilter: (filter: string) => void;
-  setPage: (page: number) => void;
-  setPageSize: (pageSize: number) => void;
+  handlePageChange: (page: number, pageSize: number) => void;
   resetFilters: () => void;
 }
 
-const stateCreator = (set: (partial: Partial<HttpStatusCodesState>) => void): HttpStatusCodesState => ({
+const stateCreator = (
+  set: (partial: Partial<HttpStatusCodesState>) => void,
+  get: () => HttpStatusCodesState
+): HttpStatusCodesState => ({
   category: DEFAULT_CATEGORY,
   filter: DEFAULT_FILTER,
   page: DEFAULT_PAGE,
   pageSize: DEFAULT_PAGE_SIZE,
+  hasFilters: () => get().category !== DEFAULT_CATEGORY || get().filter !== DEFAULT_FILTER,
   setCategory: (category) => set({ category, page: DEFAULT_PAGE }),
   setFilter: (filter) => set({ filter, page: DEFAULT_PAGE }),
-  setPage: (page) => set({ page }),
-  setPageSize: (pageSize) => set({ pageSize, page: DEFAULT_PAGE }),
+  handlePageChange: (page, pageSize) => {
+    const currentPageSize = get().pageSize;
+    if (pageSize !== currentPageSize) {
+      set({ page: DEFAULT_PAGE, pageSize });
+    } else {
+      set({ page });
+    }
+  },
   resetFilters: () =>
     set({
       category: DEFAULT_CATEGORY,

--- a/src/screens/common-lists/http-status-codes/http-status-codes.tsx
+++ b/src/screens/common-lists/http-status-codes/http-status-codes.tsx
@@ -1,15 +1,24 @@
 import { ApiOutlined } from "@ant-design/icons";
 import { Flex } from "antd";
 import { createStyles } from "antd-style";
+import { useDeferredValue } from "react";
 
 import { ScreenContainer } from "~/components/ui/screen-container";
 import { ScreenHeader } from "~/components/ui/screen-header";
 
 import { HttpStatusCodesTable } from "./http-status-codes-table";
 import { HttpStatusCodesToolbar } from "./http-status-codes-toolbar";
+import { useHttpStatusCodesStore } from "./http-status-codes.store";
+import { applyFiltering } from "./http-status-codes.utils";
 
 export const HttpStatusCodes = () => {
   const { styles } = useStyles();
+
+  const { category, filter } = useHttpStatusCodesStore();
+  const deferredCategory = useDeferredValue(category);
+  const deferredFilter = useDeferredValue(filter);
+
+  const filteredStatusCodes = applyFiltering({ category: deferredCategory, filter: deferredFilter });
 
   return (
     <ScreenContainer>
@@ -20,8 +29,8 @@ export const HttpStatusCodes = () => {
           description="Browse and search through all standard HTTP response status codes with their official descriptions from MDN Web Docs"
         />
 
-        <HttpStatusCodesToolbar />
-        <HttpStatusCodesTable />
+        <HttpStatusCodesToolbar filteredCount={filteredStatusCodes.length} />
+        <HttpStatusCodesTable filteredStatusCodes={filteredStatusCodes} />
       </Flex>
     </ScreenContainer>
   );

--- a/src/screens/common-lists/http-status-codes/http-status-codes.utils.ts
+++ b/src/screens/common-lists/http-status-codes/http-status-codes.utils.ts
@@ -43,4 +43,4 @@ export const DEFAULT_FILTER = "";
 export const DEFAULT_PAGE = 1;
 export const DEFAULT_PAGE_SIZE = 200;
 
-export const PAGE_SIZE_OPTIONS = [10, 25, 50, 100, 200];
+export const PAGE_SIZE_OPTIONS = [5, 10, 25, 50, 100, 200];

--- a/src/screens/common-lists/mime-types/mime-types-table.tsx
+++ b/src/screens/common-lists/mime-types/mime-types-table.tsx
@@ -1,31 +1,23 @@
 import { Table } from "antd";
 import { createStyles } from "antd-style";
-import { useDeferredValue } from "react";
 
 import { useResponsive } from "~/hooks/use-responsive";
 
 import { useMimeTypesStore } from "./mime-types.store";
-import { applyFiltering, PAGE_SIZE_OPTIONS } from "./mime-types.utils";
+import type { MimeTypeEntry } from "./mime-types.types";
+import { PAGE_SIZE_OPTIONS } from "./mime-types.utils";
 import { useMimeTypesColumns } from "./use-mime-types-columns";
 
-export const MimeTypesTable = () => {
+interface MimeTypesTableProps {
+  filteredMimeTypes: MimeTypeEntry[];
+}
+
+export const MimeTypesTable = ({ filteredMimeTypes }: MimeTypesTableProps) => {
   const { styles } = useStyles();
   const { isMobile } = useResponsive();
   const columns = useMimeTypesColumns();
 
-  const { category, filter, page, pageSize, setPage, setPageSize } = useMimeTypesStore();
-
-  const deferredCategory = useDeferredValue(category);
-  const deferredFilter = useDeferredValue(filter);
-
-  const filteredMimeTypes = applyFiltering({ category: deferredCategory, filter: deferredFilter });
-
-  const handlePageChange = (newPage: number, newPageSize: number) => {
-    setPage(newPage);
-    if (newPageSize !== pageSize) {
-      setPageSize(newPageSize);
-    }
-  };
+  const { page, pageSize, handlePageChange } = useMimeTypesStore();
 
   return (
     <Table

--- a/src/screens/common-lists/mime-types/mime-types-toolbar.tsx
+++ b/src/screens/common-lists/mime-types/mime-types-toolbar.tsx
@@ -1,26 +1,23 @@
 import { ClearOutlined, SearchOutlined } from "@ant-design/icons";
 import { Button, Col, Input, Row, Select, Space, Typography } from "antd";
 import { createStyles } from "antd-style";
-import { useDeferredValue } from "react";
 
 import { useResponsive } from "~/hooks/use-responsive";
 
 import { useMimeTypesStore } from "./mime-types.store";
-import { applyFiltering, CATEGORY_OPTIONS, DEFAULT_CATEGORY, MIME_TYPES } from "./mime-types.utils";
+import { CATEGORY_OPTIONS, MIME_TYPES } from "./mime-types.utils";
 
 const { Text } = Typography;
 
-export const MimeTypesToolbar = () => {
+interface MimeTypesToolbarProps {
+  filteredCount: number;
+}
+
+export const MimeTypesToolbar = ({ filteredCount }: MimeTypesToolbarProps) => {
   const { styles } = useStyles();
   const { isDesktop } = useResponsive();
 
-  const { category, filter, setCategory, setFilter, resetFilters } = useMimeTypesStore();
-
-  const deferredCategory = useDeferredValue(category);
-  const deferredFilter = useDeferredValue(filter);
-  const filteredCount = applyFiltering({ category: deferredCategory, filter: deferredFilter }).length;
-
-  const hasFilters = category !== DEFAULT_CATEGORY || filter !== "";
+  const { category, filter, setCategory, setFilter, hasFilters, resetFilters } = useMimeTypesStore();
 
   const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFilter(e.target.value);
@@ -58,11 +55,9 @@ export const MimeTypesToolbar = () => {
 
       <Col xs={12} sm={12} md={6} lg={8}>
         <Space className={styles.actions}>
-          {hasFilters && (
-            <Button icon={<ClearOutlined />} onClick={resetFilters}>
-              Clear filters
-            </Button>
-          )}
+          <Button icon={<ClearOutlined />} onClick={resetFilters} disabled={!hasFilters()}>
+            Clear filters
+          </Button>
         </Space>
       </Col>
     </Row>

--- a/src/screens/common-lists/mime-types/mime-types.store.ts
+++ b/src/screens/common-lists/mime-types/mime-types.store.ts
@@ -11,20 +11,27 @@ interface MimeTypesState {
   pageSize: number;
   setCategory: (category: MimeTypeCategory) => void;
   setFilter: (filter: string) => void;
-  setPage: (page: number) => void;
-  setPageSize: (pageSize: number) => void;
+  handlePageChange: (page: number, pageSize: number) => void;
+  hasFilters: () => boolean;
   resetFilters: () => void;
 }
 
-const stateCreator = (set: (partial: Partial<MimeTypesState>) => void): MimeTypesState => ({
+const stateCreator = (set: (partial: Partial<MimeTypesState>) => void, get: () => MimeTypesState): MimeTypesState => ({
   category: DEFAULT_CATEGORY,
   filter: DEFAULT_FILTER,
   page: DEFAULT_PAGE,
   pageSize: DEFAULT_PAGE_SIZE,
   setCategory: (category) => set({ category, page: DEFAULT_PAGE }),
   setFilter: (filter) => set({ filter, page: DEFAULT_PAGE }),
-  setPage: (page) => set({ page }),
-  setPageSize: (pageSize) => set({ pageSize, page: DEFAULT_PAGE }),
+  handlePageChange: (page, pageSize) => {
+    const currentPageSize = get().pageSize;
+    if (pageSize !== currentPageSize) {
+      set({ page: DEFAULT_PAGE, pageSize });
+    } else {
+      set({ page });
+    }
+  },
+  hasFilters: () => get().category !== DEFAULT_CATEGORY || get().filter !== DEFAULT_FILTER,
   resetFilters: () =>
     set({
       category: DEFAULT_CATEGORY,

--- a/src/screens/common-lists/mime-types/mime-types.tsx
+++ b/src/screens/common-lists/mime-types/mime-types.tsx
@@ -1,15 +1,25 @@
 import { FileTextOutlined } from "@ant-design/icons";
 import { Flex } from "antd";
 import { createStyles } from "antd-style";
+import { useDeferredValue } from "react";
 
 import { ScreenContainer } from "~/components/ui/screen-container";
 import { ScreenHeader } from "~/components/ui/screen-header";
 
+import { useMimeTypesStore } from "./mime-types.store";
 import { MimeTypesTable } from "./mime-types-table";
 import { MimeTypesToolbar } from "./mime-types-toolbar";
+import { applyFiltering } from "./mime-types.utils";
 
 export const MimeTypes = () => {
   const { styles } = useStyles();
+
+  const { category, filter } = useMimeTypesStore();
+
+  const deferredCategory = useDeferredValue(category);
+  const deferredFilter = useDeferredValue(filter);
+
+  const filteredMimeTypes = applyFiltering({ category: deferredCategory, filter: deferredFilter });
 
   return (
     <ScreenContainer>
@@ -20,8 +30,8 @@ export const MimeTypes = () => {
           description="Browse and search through standard MIME types with their associated file extensions"
         />
 
-        <MimeTypesToolbar />
-        <MimeTypesTable />
+        <MimeTypesToolbar filteredCount={filteredMimeTypes.length} />
+        <MimeTypesTable filteredMimeTypes={filteredMimeTypes} />
       </Flex>
     </ScreenContainer>
   );

--- a/src/screens/github-user-projects/github-user-projects-table.tsx
+++ b/src/screens/github-user-projects/github-user-projects-table.tsx
@@ -18,14 +18,7 @@ export const GithubUserProjectsTable = ({ projects, isLoading }: GithubUserProje
   const { isMobile } = useResponsive();
   const columns = useGithubUserProjectsColumns();
 
-  const { page, pageSize, setPage, setPageSize } = useGithubUserProjectsStore();
-
-  const handlePageChange = (newPage: number, newPageSize: number) => {
-    setPage(newPage);
-    if (newPageSize !== pageSize) {
-      setPageSize(newPageSize);
-    }
-  };
+  const { page, pageSize, handlePageChange } = useGithubUserProjectsStore();
 
   return (
     <Table

--- a/src/screens/github-user-projects/github-user-projects.store.ts
+++ b/src/screens/github-user-projects/github-user-projects.store.ts
@@ -44,12 +44,12 @@ interface GithubUserProjectsState {
   setSortOrder: (sortOrder: SortOrder) => void;
   toggleSortOrder: () => void;
   setPage: (page: number) => void;
-  setPageSize: (pageSize: number) => void;
+  handlePageChange: (page: number, pageSize: number) => void;
   resetFilters: () => void;
   resetAll: () => void;
 }
 
-const stateCreator: StateCreator<GithubUserProjectsState> = (set) => ({
+const stateCreator: StateCreator<GithubUserProjectsState> = (set, get) => ({
   // Initial state
   username: DEFAULT_USERNAME,
   lastSearchedUsername: DEFAULT_USERNAME,
@@ -76,7 +76,14 @@ const stateCreator: StateCreator<GithubUserProjectsState> = (set) => ({
       sortOrder: state.sortOrder === "asc" ? "desc" : "asc",
     })),
   setPage: (page) => set({ page }),
-  setPageSize: (pageSize) => set({ pageSize, page: DEFAULT_PAGE }),
+  handlePageChange: (page, pageSize) => {
+    const currentPageSize = get().pageSize;
+    if (pageSize !== currentPageSize) {
+      set({ page: DEFAULT_PAGE, pageSize });
+    } else {
+      set({ page });
+    }
+  },
   resetFilters: () =>
     set({
       filter: DEFAULT_FILTER,

--- a/src/screens/vr-3d-viewer/vr-3d-viewer-canvas.tsx
+++ b/src/screens/vr-3d-viewer/vr-3d-viewer-canvas.tsx
@@ -1,13 +1,14 @@
 import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
 import { createStyles } from "antd-style";
-import { Suspense, forwardRef, useImperativeHandle, useMemo, useRef } from "react";
+import { Suspense, forwardRef, useImperativeHandle, useRef } from "react";
 
 import { useResponsive } from "~/hooks/use-responsive";
 
 import { LoadingIndicator } from "./canvas/loading-indicator";
 import { SceneContent } from "./canvas/scene-content";
 import type { CameraSettings, ModelFileInfo, SceneSettings } from "./vr-3d-viewer.types";
+import { determineCanvasHeight } from "./vr-3d-viewer.utils";
 
 // Types for the component
 interface Vr3dViewerCanvasProps {
@@ -32,12 +33,7 @@ export const Vr3dViewerCanvas = forwardRef<Vr3dViewerCanvasRef, Vr3dViewerCanvas
     const containerRef = useRef<HTMLDivElement>(null);
     const controlsRef = useRef<React.ComponentRef<typeof OrbitControls> | null>(null);
 
-    // Calculate canvas height based on device
-    const canvasHeight = useMemo(() => {
-      if (isMobile) return 300;
-      if (isTablet) return 400;
-      return 500;
-    }, [isMobile, isTablet]);
+    const canvasHeight = determineCanvasHeight({ isMobile, isTablet });
 
     useImperativeHandle(ref, () => ({
       resetCamera: () => {

--- a/src/screens/vr-3d-viewer/vr-3d-viewer.utils.ts
+++ b/src/screens/vr-3d-viewer/vr-3d-viewer.utils.ts
@@ -1,7 +1,14 @@
 import prettyBytes from "pretty-bytes";
 
+import type { ResponsiveContext } from "~/utils/responsive.utils";
 import type { BoundingBox, ModelFileInfo, ModelFormat, Vector3D } from "./vr-3d-viewer.types";
 import { SUPPORTED_EXTENSIONS } from "./vr-3d-viewer.types";
+
+export const determineCanvasHeight = ({ isMobile, isTablet }: ResponsiveContext) => {
+  if (isMobile) return 300;
+  if (isTablet) return 400;
+  return 500;
+};
 
 /**
  * Detect the format of a 3D model file from its extension


### PR DESCRIPTION
## Changes Description

- Consolidated `setPage` and `setPageSize` into single `handlePageChange` method across all list stores
- Added `hasFilters()` method to stores for filter state checking
- Simplified table and toolbar components by removing duplicated pagination logic
- Applied to: named-colors, html-entities, http-headers, http-status-codes, mime-types, github-user-projects

## Checklist

- [x] code follows project [coding guidelines](https://github.com/amwebexpert/chrome-extensions-collection/blob/master/packages/coding-guide-helper/public/markdowns/table-of-content.md).
- [ ] documentation has been updated (if applicable).
- [ ] tests have been added or updated (if applicable).
- [ ] e2e tests completed

## Screen capture(s) or recording

- 🚫