### PR TITLE
feat(orchestrator): clean up implementation branches when AFK plan co…

### DIFF
--- a/ai-orchestrator/orchestrator.ts
+++ b/ai-orchestrator/orchestrator.ts
@@ -1,11 +1,12 @@
 import { logger } from "@lichens-innovation/ts-common/logger";
 import { z } from "zod";
 
+import { isNotBlank } from "@lichens-innovation/ts-common";
 import { setAgentLogDir } from "./utils/agent-logger.utils.ts";
 import { loadPrompt, runAgent, runTypedAgent } from "./utils/agent.utils.ts";
 import type { Issue, IssueWorktreeResult, OrchestratorOptions } from "./utils/orchestrator.types.ts";
 import { Plan } from "./utils/plan.ts";
-import { hasCommits, withWorktree } from "./utils/worktree.utils.ts";
+import { deleteBranch, hasCommits, withWorktree } from "./utils/worktree.utils.ts";
 
 const plannerOutputSchema = z.object({
   issues: z.array(z.object({ id: z.string(), blockedBy: z.array(z.string()) })),
@@ -16,11 +17,17 @@ const mergerOutputSchema = z.object({
   failed: z.array(z.string()),
 });
 
-type IssueWorktreeParams = {
+interface IssueWorktreeParams {
   issue: Issue;
   branch: string;
   worktreePath: string;
-};
+}
+
+interface DeleteImplementationBranchesResult {
+  deleted: string[];
+  notFound: string[];
+  failed: string[];
+}
 
 export class Orchestrator {
   private readonly repoDir: string;
@@ -56,6 +63,10 @@ export class Orchestrator {
       }
 
       await this.runMergePhase(completedIssues);
+    }
+
+    if (this.plan.remainingAfkIssues.length === 0) {
+      await this.cleanupImplementationBranches();
     }
 
     logger.info("\nAll done.");
@@ -217,6 +228,44 @@ export class Orchestrator {
     logger.info(`Merged: ${merged.length === 0 ? "none" : merged.join(", ")}`);
     if (failed.length > 0) {
       logger.info(`Failed to merge: ${failed.join(", ")}`);
+    }
+  }
+
+  private async deleteImplementationBranches(issues: Issue[]): Promise<DeleteImplementationBranchesResult> {
+    const results = await Promise.all(
+      issues.map(async (issue) => {
+        const branch = this.getBranchName(issue.id);
+        const outcome = await deleteBranch({ branch, repoDir: this.repoDir });
+        return { branch, outcome };
+      })
+    );
+
+    return {
+      deleted: results.filter((r) => r.outcome === "deleted").map((r) => r.branch),
+      notFound: results.filter((r) => r.outcome === "not-found").map((r) => r.branch),
+      failed: results.filter((r) => r.outcome === "failed").map((r) => r.branch),
+    };
+  }
+
+  private async cleanupImplementationBranches(): Promise<void> {
+    const passedAfk = this.plan.getAll().filter((issue) => issue.passes && issue.type === "AFK");
+    if (passedAfk.length === 0) {
+      return;
+    }
+
+    const { deleted, notFound, failed } = await this.deleteImplementationBranches(passedAfk);
+
+    const summaryParts = [
+      deleted.length > 0 ? `${deleted.length} deleted` : null,
+      notFound.length > 0 ? `${notFound.length} already absent` : null,
+      failed.length > 0 ? `${failed.length} failed (${failed.join(", ")})` : null,
+    ].filter(isNotBlank);
+
+    const message = `Cleaned up implementation branches: ${summaryParts.join(", ")}`;
+    if (failed.length > 0) {
+      logger.warn(message);
+    } else {
+      logger.info(message);
     }
   }
 }

--- a/ai-orchestrator/utils/worktree.utils.ts
+++ b/ai-orchestrator/utils/worktree.utils.ts
@@ -74,7 +74,6 @@ interface RemoveWorktreeArgs {
   name: string;
   dir: string;
   force?: boolean;
-  /** Missing worktrees are expected during branch cleanup; log at debug instead of error. */
   quietIfMissing?: boolean;
 }
 

--- a/ai-orchestrator/utils/worktree.utils.ts
+++ b/ai-orchestrator/utils/worktree.utils.ts
@@ -74,16 +74,23 @@ interface RemoveWorktreeArgs {
   name: string;
   dir: string;
   force?: boolean;
+  /** Missing worktrees are expected during branch cleanup; log at debug instead of error. */
+  quietIfMissing?: boolean;
 }
 
-const removeWorktree = async ({ name, dir, force }: RemoveWorktreeArgs): Promise<void> => {
+const removeWorktree = async ({ name, dir, force, quietIfMissing }: RemoveWorktreeArgs): Promise<void> => {
   const worktreePath = getWorktreePath({ repoDir: dir, branch: name });
   const forceFlag = force ? ["--force"] : [];
   const args = ["worktree", "remove", ...forceFlag, worktreePath];
   try {
     await runGit({ args, cwd: dir });
   } catch (error) {
-    logger.error(`Failed to remove worktree at "${worktreePath}"`, { error });
+    const message = `Failed to remove worktree at "${worktreePath}"`;
+    if (quietIfMissing) {
+      logger.debug(message, { error });
+    } else {
+      logger.error(message, { error });
+    }
   }
 };
 
@@ -116,5 +123,31 @@ export const hasCommits = ({ branch, repoDir }: HasCommitsArgs): boolean => {
   } catch (error) {
     logger.error(`Failed to inspect commits for branch "${branch}"`, { error });
     return false;
+  }
+};
+
+export type DeleteBranchResult = "deleted" | "not-found" | "failed";
+
+export interface DeleteBranchArgs {
+  branch: string;
+  repoDir: string;
+}
+
+export const deleteBranch = async ({ branch, repoDir }: DeleteBranchArgs): Promise<DeleteBranchResult> => {
+  await removeWorktree({ name: branch, dir: repoDir, force: true, quietIfMissing: true });
+  const exists = await branchExists({ branch, repoDir });
+
+  if (!exists) {
+    logger.debug(`Branch "${branch}" already absent`);
+    return "not-found";
+  }
+
+  try {
+    await runGit({ args: ["branch", "-d", branch], cwd: repoDir });
+    logger.info(`Deleted branch "${branch}"`);
+    return "deleted";
+  } catch (error) {
+    logger.warn(`Could not delete branch "${branch}"`, { error });
+    return "failed";
   }
 };


### PR DESCRIPTION
## Changes Description

- **Orchestrator:** After merge phase, when no AFK issues remain, deletes implementation branches for all passed AFK issues and logs a summary (deleted / already absent / failed).
- **Worktree:** Adds `deleteBranch` (force-remove worktree, then `git branch -d`) and `quietIfMissing` on worktree removal so missing worktrees during cleanup log at debug instead of error.

## Checklist

- [ ] code follows project [coding guidelines](https://github.com/amwebexpert/chrome-extensions-collection/blob/master/packages/coding-guide-helper/public/markdowns/table-of-content.md).
- [ ] documentation has been updated (if applicable).
- [ ] tests have been added or updated (if applicable).
- [ ] e2e tests completed

## Screen capture(s) or recording

- 🚫