### PR TITLE
test(e2e): add mobile/tablet projects and fix responsive UI issues

### DIFF
--- a/.habit-hooks/config.toml
+++ b/.habit-hooks/config.toml
@@ -16,6 +16,7 @@ guide = "sonarjs-cognitive-complexity.md"
 
 [smells.non-essential-comment]
 severity = "enforced"
+guide = "non-essential-comment.md"
 
 [smells.duplicated-code]
 severity = "enforced"

--- a/.habit-hooks/typescript/guides/non-essential-comment.md
+++ b/.habit-hooks/typescript/guides/non-essential-comment.md
@@ -1,0 +1,13 @@
+Comments indicate code that is not self-documenting. The smell is the *need* for the comment — the reader could not work out what the code does from the names and structure alone.
+
+Extract complex logic into well-named functions instead of explaining with a comment. A function called `applyDiscountForLoyalCustomers` does not need a header explaining what it does.
+
+Remove comments unless they impact functionality (executable annotations) or explain *why* something non-obvious was chosen (a workaround for a specific library bug, a reference to a spec). Comments that explain *what* the code does are almost always redundant — or worse, drift out of sync with the code and start lying.
+
+Do not delete an `eslint-disable` or shebang on autopilot — those are flagged separately and exempted from this rule.
+
+**When the comment must stay**: If the code is already as clear as it can be and the comment explains *why* — not *what* — keep it. Put `habit-hooks-disable non-essential-comment` on the same line. That suppresses the finding and signals you've checked: this isn't redundant narration, it's necessary context (workaround, constraint, spec link, etc.).
+
+**AVOID**: using the disable to keep comments that merely restate what the code does. If a better name or extraction removes the need, do that instead.
+
+{% include "includes/line_level_issues.md" %}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # Web Toolbox
 
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue.svg?style=flat-square&logo=typescript)](https://www.typescriptlang.org/)
-[![Node.js](https://img.shields.io/badge/Node.js-LTS-green.svg?style=flat-square&logo=node.js)](https://nodejs.org/)
-[![Vitest](https://img.shields.io/badge/Vitest-4.0-6E9F18.svg?style=flat-square&logo=vitest)](https://vitest.dev/)
-[![Bun](https://img.shields.io/badge/Bun-1.3+-000000.svg?style=flat-square&logo=bun)](https://bun.sh/)
+[![CI](https://github.com/amwebexpert/etoolbox/actions/workflows/ci.yml/badge.svg)](https://github.com/amwebexpert/etoolbox/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](./LICENSE)
+[![GitHub Pages](https://img.shields.io/badge/GitHub_Pages-live-222222.svg?style=flat-square&logo=githubpages&logoColor=white)](https://amwebexpert.github.io/etoolbox)
+
+[![React](https://img.shields.io/badge/React-19-61DAFB.svg?style=flat-square&logo=react&logoColor=white)](https://react.dev/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg?style=flat-square&logo=typescript)](https://www.typescriptlang.org/)
+[![Ant Design](https://img.shields.io/badge/Ant_Design-6-0170FE.svg?style=flat-square&logo=antdesign)](https://ant.design/)
+[![Vite](https://img.shields.io/badge/Vite_(Rolldown)-7.3-646CFF.svg?style=flat-square&logo=vite)](https://rolldown.rs/)
+[![Bun](https://img.shields.io/badge/Bun-1.3.14-000000.svg?style=flat-square&logo=bun)](https://bun.sh/)
+[![Vitest](https://img.shields.io/badge/Vitest-4.1-6E9F18.svg?style=flat-square&logo=vitest)](https://vitest.dev/)
+[![Playwright](https://img.shields.io/badge/Playwright-1.62-2EAD33.svg?style=flat-square&logo=playwright)](https://playwright.dev/)
 
 Open source collection of web developer utilities.
 The web application has been deployed and you can use it [just here!](https://amwebexpert.github.io/etoolbox)
@@ -29,6 +36,14 @@ The web application has been deployed and you can use it [just here!](https://am
 | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | <img alt="Green theme" src="public/screen-captures/screen-home.png" /> | <img alt="Blue theme" src="public/screen-captures/screen-home-mobile.png" /> |
 
+## Getting Started
+
+1. Install dependencies: `bun install`
+2. (Recommended) Install habit-hooks for local lint coaching: `uv tool install "habit-hooks[typescript]"`
+3. Start the dev server: `bun start` (http://localhost:5173)
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for full contributor setup and conventions.
+
 ## Development commands
 
 | Script                        | Description                                                                             |
@@ -39,7 +54,12 @@ The web application has been deployed and you can use it [just here!](https://am
 | `bun run preview`             | Previews the production build locally (from `dist/`)                                    |
 | `bun run deploy`              | Rebuilds the app and moves output to `docs/` for GitHub Pages deployment                |
 | `bun run test`                | Runs tests with Vitest                                                                  |
-| `bun run lint`                | Runs ESLint on the codebase                                                             |
+| `bun run test:e2e`              | Runs Playwright e2e tests (Chromium desktop)                                            |
+| `bun run test:e2e:ui`           | Runs e2e tests in Playwright UI mode                                                    |
+| `bun run test:e2e:responsive`   | Runs e2e tests on mobile and tablet viewports                                           |
+| `bun run test:e2e:all`            | Runs e2e tests across all Playwright projects                                           |
+| `bun run test:e2e:report`         | Opens the HTML test report                                                              |
+| `bun run lint`                | Runs habit-hooks code-quality coaching on the codebase                                  |
 | `bun run typecheck`           | Runs TypeScript type checking without emitting files                                    |
 | `bun run format`              | Formats code with Prettier                                                              |
 | `bun run format:check`        | Checks code formatting without making changes                                           |
@@ -48,31 +68,34 @@ The web application has been deployed and you can use it [just here!](https://am
 | `bun run generate:api:client` | Generates API client from OpenAPI specification                                         |
 | `bun run postinstall`         | Runs after install: applies patches                                                     |
 
+Playwright starts the Vite dev server automatically via [e2e/playwright.config.ts](./e2e/playwright.config.ts). E2E tests run locally only (not in CI).
+
 ## Frameworks & Dependencies
 
-| Package                                         | Description                                        |
-| ----------------------------------------------- | -------------------------------------------------- |
-| [React](https://react.dev/)                     | UI library for building component-based interfaces |
-| [TypeScript](https://www.typescriptlang.org/)   | Type-safe JavaScript superset                      |
-| [Ant Design](https://ant.design/)               | Enterprise-class UI component library              |
-| [TanStack Router](https://tanstack.com/router)  | Type-safe routing for React                        |
-| [TanStack Query](https://tanstack.com/query)    | Async state management and data fetching           |
-| [Zustand](https://zustand-demo.pmnd.rs/)        | Lightweight state management                       |
-| [Immer](https://immerjs.github.io/immer/)       | Immutable state with mutable syntax                |
-| [Axios](https://axios-http.com/)                | HTTP client                                        |
-| [React Hook Form](https://react-hook-form.com/) | Performant form handling                           |
-| [@uidotdev/usehooks](https://usehooks.com/)     | Collection of React hooks                          |
+| Package                                                       | Description                                        |
+| ------------------------------------------------------------- | -------------------------------------------------- |
+| [React](https://react.dev/)                                   | UI library for building component-based interfaces |
+| [TypeScript](https://www.typescriptlang.org/)                 | Type-safe JavaScript superset                      |
+| [Ant Design](https://ant.design/)                             | Enterprise-class UI component library              |
+| [TanStack Router](https://tanstack.com/router)                | Type-safe routing for React                        |
+| [TanStack Query](https://tanstack.com/query)                  | Async state management and data fetching           |
+| [Zustand](https://zustand-demo.pmnd.rs/)                      | Lightweight state management                       |
+| [Immer](https://immerjs.github.io/immer/)                     | Immutable state with mutable syntax                |
+| [@lichens-innovation/ts-common](https://www.npmjs.com/package/@lichens-innovation/ts-common) | Shared TypeScript utilities                        |
+| [@uidotdev/usehooks](https://usehooks.com/)                   | Collection of React hooks                          |
 
 ## Development Tools
 
-| Package                                    | Description                     |
-| ------------------------------------------ | ------------------------------- |
-| [Vite (Rolldown)](https://rolldown.rs/)    | Next-generation fast build tool |
-| [Vitest](https://vitest.dev/)              | Unit testing framework          |
-| [ESLint](https://eslint.org/)              | JavaScript/TypeScript linting   |
-| [Prettier](https://prettier.io/)           | Code formatting                 |
-| [Husky](https://typicode.github.io/husky/) | Git hooks management            |
-| [Commitlint](https://commitlint.js.org/)   | Commit message linting          |
+| Package                                                   | Description                                   |
+| --------------------------------------------------------- | --------------------------------------------- |
+| [Vite (Rolldown)](https://rolldown.rs/)                   | Next-generation fast build tool               |
+| [Vitest](https://vitest.dev/)                             | Unit testing framework                        |
+| [Playwright](https://playwright.dev/)                     | End-to-end browser testing                    |
+| [ESLint](https://eslint.org/)                             | JavaScript/TypeScript linting                 |
+| [habit-hooks](https://github.com/habit-hooks/habit-hooks) | Code-quality coaching (powers `bun run lint`) |
+| [Prettier](https://prettier.io/)                          | Code formatting                               |
+| [Husky](https://typicode.github.io/husky/)                | Git hooks management                          |
+| [Commitlint](https://commitlint.js.org/)                  | Commit message linting                        |
 
 ## Technical Notes
 

--- a/e2e/pages/common-lists-page.ts
+++ b/e2e/pages/common-lists-page.ts
@@ -34,4 +34,12 @@ export class CommonListsPage {
   heading(title: string): Locator {
     return this.page.getByRole("heading", { name: title });
   }
+
+  /** Scroll overflowed Ant Design tabs into view before clicking (narrow viewports). habit-hooks-disable non-essential-comment */
+  async clickTab(tab: Locator): Promise<void> {
+    await tab.evaluate((element) => {
+      element.scrollIntoView({ block: "nearest", inline: "center" });
+    });
+    await tab.click({ force: true });
+  }
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -14,7 +14,18 @@ export default defineConfig({
     screenshot: "only-on-failure",
     video: "retain-on-failure",
   },
-  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    { name: "mobile-chrome", use: { ...devices["Pixel 7"] } },
+    {
+      name: "tablet",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 768, height: 1024 },
+        hasTouch: true,
+      },
+    },
+  ],
   webServer: {
     command: "bun run dev",
     cwd: process.cwd(),

--- a/e2e/tests/common-lists/common-lists-tabs.spec.ts
+++ b/e2e/tests/common-lists/common-lists-tabs.spec.ts
@@ -53,25 +53,25 @@ test("can navigate between all common-lists tabs", async ({ page, commonListsPag
   await expect(commonListsPage.heading("MIME Types")).toBeVisible();
 
   // act & assert — html entities
-  await commonListsPage.htmlEntitiesTab.click();
+  await commonListsPage.clickTab(commonListsPage.htmlEntitiesTab);
   await expect(page).toHaveURL(/#\/common-lists\/html-entities$/);
   await expect(commonListsPage.htmlEntitiesTab).toHaveAttribute("aria-selected", "true");
   await expect(commonListsPage.heading("HTML Entities")).toBeVisible();
 
   // act & assert — http status codes
-  await commonListsPage.httpStatusCodesTab.click();
+  await commonListsPage.clickTab(commonListsPage.httpStatusCodesTab);
   await expect(page).toHaveURL(/#\/common-lists\/http-status-codes$/);
   await expect(commonListsPage.httpStatusCodesTab).toHaveAttribute("aria-selected", "true");
   await expect(commonListsPage.heading("HTTP Status Codes")).toBeVisible();
 
   // act & assert — http headers
-  await commonListsPage.httpHeadersTab.click();
+  await commonListsPage.clickTab(commonListsPage.httpHeadersTab);
   await expect(page).toHaveURL(/#\/common-lists\/http-headers$/);
   await expect(commonListsPage.httpHeadersTab).toHaveAttribute("aria-selected", "true");
   await expect(commonListsPage.heading("HTTP Headers")).toBeVisible();
 
   // act & assert — back to mime-types
-  await commonListsPage.mimeTypesTab.click();
+  await commonListsPage.clickTab(commonListsPage.mimeTypesTab);
   await expect(page).toHaveURL(/#\/common-lists\/mime-types$/);
   await expect(commonListsPage.mimeTypesTab).toHaveAttribute("aria-selected", "true");
   await expect(commonListsPage.heading("MIME Types")).toBeVisible();

--- a/e2e/tests/date-converter/date-converter.spec.ts
+++ b/e2e/tests/date-converter/date-converter.spec.ts
@@ -14,11 +14,11 @@ test("clicking Now populates the result table with date formats", async ({ page,
   // act
   await page.getByRole("button", { name: "Now" }).click();
 
-  // assert
+  // assert — labels render as table cells (desktop) or cards (mobile)
   await expect(dateConverterPage.heading("Date & Epoch Converter")).toBeVisible();
-  await expect(page.getByRole("cell", { name: "ISO 8601 / JSON" })).toBeVisible();
-  await expect(page.getByRole("cell", { name: "Epoch (milliseconds)" })).toBeVisible();
-  await expect(page.getByRole("cell", { name: "UTC String" })).toBeVisible();
+  await expect(page.getByText("ISO 8601 / JSON", { exact: true })).toBeVisible();
+  await expect(page.getByText("Epoch (milliseconds)", { exact: true })).toBeVisible();
+  await expect(page.getByText("UTC String", { exact: true })).toBeVisible();
 });
 
 test("non-numeric epoch value shows a validation error", async ({ page }) => {
@@ -38,7 +38,7 @@ test("quick dates sets the start of day", async ({ page }) => {
   await page.getByRole("menuitem", { name: "Start of Day (00:00)" }).click();
 
   // assert
-  await expect(page.getByRole("cell", { name: "Time Only (HH:mm:ss)" })).toBeVisible();
+  await expect(page.getByText("Time Only (HH:mm:ss)", { exact: true })).toBeVisible();
   const epochInput = page.getByPlaceholder("Enter epoch timestamp");
   await expect(epochInput).not.toHaveValue("");
 });
@@ -58,7 +58,7 @@ test("toggling code examples hides the code examples section", async ({ page }) 
 test("clear resets to the empty placeholder", async ({ page }) => {
   // arrange
   await page.getByRole("button", { name: "Now" }).click();
-  await expect(page.getByRole("cell", { name: "ISO 8601 / JSON" })).toBeVisible();
+  await expect(page.getByText("ISO 8601 / JSON", { exact: true })).toBeVisible();
 
   // act
   await page.getByRole("button", { name: "Clear" }).click();

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "test": "vitest",
     "test:e2e": "playwright test --config e2e/playwright.config.ts --project=chromium",
     "test:e2e:ui": "playwright test --config e2e/playwright.config.ts --ui --project=chromium",
+    "test:e2e:responsive": "playwright test --config e2e/playwright.config.ts --project=mobile-chrome --project=tablet",
+    "test:e2e:all": "playwright test --config e2e/playwright.config.ts",
     "test:e2e:report": "playwright show-report e2e/playwright-report",
     "test:e2e:report:open": "open e2e/playwright-report/index.html",
     "lint-staged": "lint-staged",

--- a/src/components/layout/app-layout-tabs.tsx
+++ b/src/components/layout/app-layout-tabs.tsx
@@ -34,18 +34,35 @@ export const AppLayoutTabs = ({ items }: AppLayoutTabsProps) => {
   );
 };
 
-const useStyles = createStyles(({ token }) => ({
+const useStyles = createStyles(({ token, css }) => ({
   container: {
     display: "flex",
     flexDirection: "column",
     height: "100%",
   },
-  tabs: {
-    marginBottom: 0,
-    "& .ant-tabs-nav": {
-      marginBottom: 0,
-    },
-  },
+  tabs: css`
+    margin-bottom: 0;
+
+    & .ant-tabs-nav {
+      margin-bottom: 0;
+    }
+
+    /* Keep all tabs reachable on narrow viewports (no off-screen overflow scroll). */
+    @media (max-width: 576px) {
+      & .ant-tabs-nav-wrap {
+        overflow: visible;
+      }
+
+      & .ant-tabs-nav-list {
+        flex-wrap: wrap;
+        transform: none !important;
+      }
+
+      & .ant-tabs-nav-operations {
+        display: none;
+      }
+    }
+  `,
   content: {
     flex: 1,
     borderTop: `1px solid ${token.colorBorderSecondary}`,

--- a/src/components/ui/encode-decode-toolbar.tsx
+++ b/src/components/ui/encode-decode-toolbar.tsx
@@ -27,22 +27,22 @@ export const EncodeDecodeToolbar = ({
     <ScreenToolbar
       leading={
         <Tooltip title="Swap: put result into input">
-          <Button icon={<SwapOutlined />} disabled={!hasOutput} onClick={onSwap} />
+          <Button aria-label="Swap" icon={<SwapOutlined />} disabled={!hasOutput} onClick={onSwap} />
         </Tooltip>
       }
       actions={
         <Space size="small" wrap>
           <Tooltip title="Copy result to clipboard">
-            <Button icon={<CopyOutlined />} disabled={!hasOutput} onClick={onCopy}>
+            <Button aria-label="Copy" icon={<CopyOutlined />} disabled={!hasOutput} onClick={onCopy}>
               {!isMobile && "Copy"}
             </Button>
           </Tooltip>
 
-          <Button type="primary" icon={<CodeOutlined />} disabled={!hasInput} onClick={onEncode}>
+          <Button type="primary" aria-label="Encode" icon={<CodeOutlined />} disabled={!hasInput} onClick={onEncode}>
             {isMobile ? "Enc." : "Encode"}
           </Button>
 
-          <Button type="primary" icon={<UnlockOutlined />} disabled={!hasInput} onClick={onDecode}>
+          <Button type="primary" aria-label="Decode" icon={<UnlockOutlined />} disabled={!hasInput} onClick={onDecode}>
             {isMobile ? "Dec." : "Decode"}
           </Button>
         </Space>

--- a/src/screens/base64/data-uri/data-uri-toolbar.tsx
+++ b/src/screens/base64/data-uri/data-uri-toolbar.tsx
@@ -23,7 +23,13 @@ export const DataUriToolbar = ({ hasContent, canDownload, onClear, onDownload }:
       }
       actions={
         <Tooltip title="Download the decoded image">
-          <Button type="primary" icon={<DownloadOutlined />} disabled={!canDownload} onClick={onDownload}>
+          <Button
+            type="primary"
+            aria-label="Download"
+            icon={<DownloadOutlined />}
+            disabled={!canDownload}
+            onClick={onDownload}
+          >
             {isMobile ? "DL" : "Download"}
           </Button>
         </Tooltip>

--- a/src/screens/base64/file/base64-file-toolbar.tsx
+++ b/src/screens/base64/file/base64-file-toolbar.tsx
@@ -31,19 +31,25 @@ export const Base64FileToolbar = ({
       actions={
         <Space size="small" wrap>
           <Tooltip title="Copy raw Base64 to clipboard">
-            <Button icon={<CopyOutlined />} disabled={!hasContent} onClick={onCopy}>
+            <Button aria-label="Copy Base64" icon={<CopyOutlined />} disabled={!hasContent} onClick={onCopy}>
               {!isMobile && "Copy Base64"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Copy as Data URI (data:mime;base64,...)">
-            <Button icon={<CopyOutlined />} disabled={!hasContent} onClick={onCopyDataUri}>
+            <Button aria-label="Copy Data URI" icon={<CopyOutlined />} disabled={!hasContent} onClick={onCopyDataUri}>
               {!isMobile && "Copy Data URI"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Decode Base64 and download as file">
-            <Button type="primary" icon={<DownloadOutlined />} disabled={!hasContent} onClick={onDownload}>
+            <Button
+              type="primary"
+              aria-label="Download"
+              icon={<DownloadOutlined />}
+              disabled={!hasContent}
+              onClick={onDownload}
+            >
               {isMobile ? "DL" : "Download"}
             </Button>
           </Tooltip>

--- a/src/screens/colors/picker/color-picker-toolbar.tsx
+++ b/src/screens/colors/picker/color-picker-toolbar.tsx
@@ -24,14 +24,14 @@ export const ColorPickerToolbar = ({ hasImage, onClear, onFileSelect }: ColorPic
       actions={
         <Space size="small" wrap>
           <Tooltip title="Clear image">
-            <Button icon={<ClearOutlined />} disabled={!hasImage} onClick={onClear}>
+            <Button aria-label="Clear" icon={<ClearOutlined />} disabled={!hasImage} onClick={onClear}>
               {!isMobile && "Clear"}
             </Button>
           </Tooltip>
 
           <Upload accept="image/*" showUploadList={false} beforeUpload={handleBeforeUpload}>
             <Tooltip title="Select image from file">
-              <Button type="primary" icon={<UploadOutlined />}>
+              <Button type="primary" aria-label="Select Image" icon={<UploadOutlined />}>
                 {isMobile ? "Image" : "Select Image"}
               </Button>
             </Tooltip>

--- a/src/screens/common-lists/html-entities/use-html-entities-columns.tsx
+++ b/src/screens/common-lists/html-entities/use-html-entities-columns.tsx
@@ -116,16 +116,15 @@ export const useHtmlEntitiesColumns = (): ColumnsType<HtmlEntity> => {
     });
   }
 
-  if (!isMobile) {
-    columns.push({
-      title: "Description",
-      dataIndex: "description",
-      key: "description",
-      ellipsis: true,
-      sorter: (a, b) => a.description.localeCompare(b.description),
-      render: (description: string) => <Text className={styles.descriptionText}>{description}</Text>,
-    });
-  }
+  columns.push({
+    title: "Description",
+    dataIndex: "description",
+    key: "description",
+    ellipsis: true,
+    width: isMobile ? 100 : undefined,
+    sorter: (a, b) => a.description.localeCompare(b.description),
+    render: (description: string) => <Text className={styles.descriptionText}>{description}</Text>,
+  });
 
   if (!isMobile && !isTablet) {
     columns.push({

--- a/src/screens/csv-parser/csv-parser-toolbar.tsx
+++ b/src/screens/csv-parser/csv-parser-toolbar.tsx
@@ -51,19 +51,19 @@ export const CsvParserToolbar = ({
       actions={
         <Space size="small" wrap>
           <Tooltip title="Clear all fields">
-            <Button icon={<ClearOutlined />} disabled={!hasContent && !hasResult} onClick={onClear}>
+            <Button aria-label="Clear" icon={<ClearOutlined />} disabled={!hasContent && !hasResult} onClick={onClear}>
               {!isMobile && "Clear"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Copy parsed result to clipboard">
-            <Button icon={<CopyOutlined />} disabled={!hasResult} onClick={onCopy}>
+            <Button aria-label="Copy" icon={<CopyOutlined />} disabled={!hasResult} onClick={onCopy}>
               {!isMobile && "Copy"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Download as JSON file">
-            <Button icon={<DownloadOutlined />} disabled={!hasResult} onClick={onDownload}>
+            <Button aria-label="Save" icon={<DownloadOutlined />} disabled={!hasResult} onClick={onDownload}>
               {!isMobile && "Save"}
             </Button>
           </Tooltip>

--- a/src/screens/date-converter/date-converter-toolbar.tsx
+++ b/src/screens/date-converter/date-converter-toolbar.tsx
@@ -78,13 +78,13 @@ export const DateConverterToolbar = ({
       actions={
         <Space size="small" wrap>
           <Tooltip title="Clear all">
-            <Button icon={<ClearOutlined />} disabled={!hasDate} onClick={onClear}>
+            <Button aria-label="Clear" icon={<ClearOutlined />} disabled={!hasDate} onClick={onClear}>
               {!isMobile && "Clear"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Copy all formats to clipboard">
-            <Button icon={<CopyOutlined />} disabled={!hasDate} onClick={onCopyAll}>
+            <Button aria-label="Copy All" icon={<CopyOutlined />} disabled={!hasDate} onClick={onCopyAll}>
               {!isMobile && "Copy All"}
             </Button>
           </Tooltip>

--- a/src/screens/date-converter/results/date-format-card.tsx
+++ b/src/screens/date-converter/results/date-format-card.tsx
@@ -24,6 +24,7 @@ export const DateFormatCard = ({ format, date, epochValue, onCopy }: DateFormatC
         <Button
           type="text"
           size="small"
+          aria-label={`Copy ${format.label}`}
           icon={<CopyOutlined />}
           onClick={() => onCopy({ value: displayValue, label: format.label })}
         />

--- a/src/screens/date-converter/results/result-mobile-layout.tsx
+++ b/src/screens/date-converter/results/result-mobile-layout.tsx
@@ -1,5 +1,5 @@
 import { CodeOutlined } from "@ant-design/icons";
-import { Collapse } from "antd";
+import { Typography } from "antd";
 import { createStyles } from "antd-style";
 
 import { useSyntaxHighlightTheme } from "~/hooks/use-syntax-highlight-theme";
@@ -27,32 +27,14 @@ export const ResultMobileLayout = ({ date, epochValue, showCodeExamples, onCopy 
       ))}
 
       {showCodeExamples ? (
-        <Collapse
-          className={styles.codeExamplesCollapse}
-          items={[
-            {
-              key: "code-examples",
-              label: (
-                <span>
-                  <CodeOutlined /> Code Examples
-                </span>
-              ),
-              children: (
-                <>
-                  {CODE_EXAMPLES.map((example) => (
-                    <CodeExampleCard
-                      key={example.id}
-                      example={example}
-                      date={date}
-                      onCopy={onCopy}
-                      syntaxTheme={syntaxTheme}
-                    />
-                  ))}
-                </>
-              ),
-            },
-          ]}
-        />
+        <div className={styles.codeExamplesSection}>
+          <Typography.Title level={5} className={styles.codeExamplesTitle}>
+            <CodeOutlined /> Code Examples
+          </Typography.Title>
+          {CODE_EXAMPLES.map((example) => (
+            <CodeExampleCard key={example.id} example={example} date={date} onCopy={onCopy} syntaxTheme={syntaxTheme} />
+          ))}
+        </div>
       ) : null}
     </div>
   );
@@ -64,7 +46,13 @@ const useStyles = createStyles(() => ({
     flexDirection: "column",
     gap: 12,
   },
-  codeExamplesCollapse: {
+  codeExamplesSection: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 12,
     marginTop: 8,
+  },
+  codeExamplesTitle: {
+    margin: 0,
   },
 }));

--- a/src/screens/github-user-projects/github-filters-row.tsx
+++ b/src/screens/github-user-projects/github-filters-row.tsx
@@ -120,7 +120,7 @@ export const GithubFiltersRow = ({ projects }: GithubFiltersRowProps) => {
       {hasFilters ? (
         <Col xs={6} sm={4} md={3} lg={2}>
           <Tooltip title="Clear all filters">
-            <Button icon={<ClearOutlined />} onClick={resetFilters} size="small">
+            <Button aria-label="Clear" icon={<ClearOutlined />} onClick={resetFilters} size="small">
               {!isMobile && "Clear"}
             </Button>
           </Tooltip>

--- a/src/screens/github-user-projects/github-search-row.tsx
+++ b/src/screens/github-user-projects/github-search-row.tsx
@@ -62,6 +62,7 @@ export const GithubSearchRow = ({
         <Space size="small" className={styles.searchActions}>
           <Button
             type="primary"
+            aria-label="Search"
             icon={<SearchOutlined />}
             onClick={onSearch}
             loading={isLoading}

--- a/src/screens/image-tools/compressor/compressor-toolbar.tsx
+++ b/src/screens/image-tools/compressor/compressor-toolbar.tsx
@@ -28,13 +28,13 @@ export const CompressorToolbar = ({
       actions={
         <Space size="small" wrap>
           <Tooltip title="Clear selected image and compression result">
-            <Button icon={<ClearOutlined />} disabled={!hasFile && !hasResult} onClick={onClear}>
+            <Button aria-label="Clear" icon={<ClearOutlined />} disabled={!hasFile && !hasResult} onClick={onClear}>
               {!isMobile && "Clear"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Download the compressed image">
-            <Button icon={<DownloadOutlined />} disabled={!hasResult} onClick={onDownload}>
+            <Button aria-label="Download" icon={<DownloadOutlined />} disabled={!hasResult} onClick={onDownload}>
               {!isMobile && "Download"}
             </Button>
           </Tooltip>

--- a/src/screens/image-tools/ocr/ocr-toolbar.tsx
+++ b/src/screens/image-tools/ocr/ocr-toolbar.tsx
@@ -42,19 +42,19 @@ export const OcrToolbar = ({ hasImage, resultText, isProcessing, onProcess, onCl
       actions={
         <Space size="small" wrap>
           <Tooltip title="Clear image and result">
-            <Button icon={<ClearOutlined />} disabled={!hasImage && !hasResult} onClick={onClear}>
+            <Button aria-label="Clear" icon={<ClearOutlined />} disabled={!hasImage && !hasResult} onClick={onClear}>
               {!isMobile && "Clear"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Copy extracted text to clipboard">
-            <Button icon={<CopyOutlined />} disabled={!hasResult} onClick={handleCopy}>
+            <Button aria-label="Copy" icon={<CopyOutlined />} disabled={!hasResult} onClick={handleCopy}>
               {!isMobile && "Copy"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Download extracted text as file">
-            <Button icon={<DownloadOutlined />} disabled={!hasResult} onClick={handleDownload}>
+            <Button aria-label="Download" icon={<DownloadOutlined />} disabled={!hasResult} onClick={handleDownload}>
               {!isMobile && "Download"}
             </Button>
           </Tooltip>
@@ -62,6 +62,7 @@ export const OcrToolbar = ({ hasImage, resultText, isProcessing, onProcess, onCl
           <Tooltip title="Run OCR to extract text from image">
             <Button
               type="primary"
+              aria-label="Run OCR"
               icon={<ScanOutlined />}
               disabled={!hasImage}
               loading={isProcessing}

--- a/src/screens/json/converter/json-converter-toolbar.tsx
+++ b/src/screens/json/converter/json-converter-toolbar.tsx
@@ -28,13 +28,13 @@ export const JsonConverterToolbar = ({
       actions={
         <Space size="small" wrap>
           <Tooltip title="Clear all fields">
-            <Button icon={<ClearOutlined />} disabled={!hasContent && !hasResult} onClick={onClear}>
+            <Button aria-label="Clear" icon={<ClearOutlined />} disabled={!hasContent && !hasResult} onClick={onClear}>
               {!isMobile && "Clear"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Copy converted result to clipboard">
-            <Button icon={<CopyOutlined />} disabled={!hasResult} onClick={onCopy}>
+            <Button aria-label="Copy" icon={<CopyOutlined />} disabled={!hasResult} onClick={onCopy}>
               {!isMobile && "Copy"}
             </Button>
           </Tooltip>

--- a/src/screens/json/formatter/json-formatter-toolbar.tsx
+++ b/src/screens/json/formatter/json-formatter-toolbar.tsx
@@ -36,18 +36,18 @@ export const JsonFormatterToolbar = ({
   return (
     <ScreenToolbar
       leading={
-        <Tooltip title="Choose how to display the formatted JSON">
+        <Tooltip title="Choose how to display the formatted JSON" trigger={isMobile ? [] : ["hover"]}>
           <Segmented
             value={viewMode}
             onChange={(value) => onViewModeChange(value as ViewMode)}
             options={[
               {
-                label: isMobile ? "Syntax" : "Syntax Highlight",
+                label: "Syntax Highlight",
                 value: "syntax-highlight",
                 icon: <FormatPainterOutlined />,
               },
               {
-                label: isMobile ? "Interactive" : "Interactive View",
+                label: "Interactive View",
                 value: "react-json-view",
                 icon: <EyeOutlined />,
               },
@@ -58,7 +58,10 @@ export const JsonFormatterToolbar = ({
       }
       actions={
         <Space size="small" wrap>
-          <Tooltip title={isMinified ? "Format JSON with indentation" : "Minify JSON (remove whitespace)"}>
+          <Tooltip
+            title={isMinified ? "Format JSON with indentation" : "Minify JSON (remove whitespace)"}
+            trigger={isMobile ? [] : ["hover"]}
+          >
             <Button
               type="primary"
               icon={isMinified ? <FormatPainterOutlined /> : <CompressOutlined />}
@@ -69,14 +72,14 @@ export const JsonFormatterToolbar = ({
             </Button>
           </Tooltip>
 
-          <Tooltip title="Copy formatted JSON to clipboard">
-            <Button icon={<CopyOutlined />} disabled={!hasContent} onClick={onCopy}>
+          <Tooltip title="Copy formatted JSON to clipboard" trigger={isMobile ? [] : ["hover"]}>
+            <Button aria-label="Copy" icon={<CopyOutlined />} disabled={!hasContent} onClick={onCopy}>
               {!isMobile && "Copy"}
             </Button>
           </Tooltip>
 
-          <Tooltip title="Save JSON to file">
-            <Button icon={<DownloadOutlined />} disabled={!hasContent} onClick={onSaveAs}>
+          <Tooltip title="Save JSON to file" trigger={isMobile ? [] : ["hover"]}>
+            <Button aria-label="Save As…" icon={<DownloadOutlined />} disabled={!hasContent} onClick={onSaveAs}>
               {isMobile ? "Save" : "Save As…"}
             </Button>
           </Tooltip>

--- a/src/screens/json/repair/json-repair-toolbar.tsx
+++ b/src/screens/json/repair/json-repair-toolbar.tsx
@@ -30,19 +30,19 @@ export const JsonRepairToolbar = ({
       actions={
         <Space size="small" wrap>
           <Tooltip title="Clear input and result">
-            <Button icon={<ClearOutlined />} disabled={!hasInput && !hasResult} onClick={onClear}>
+            <Button aria-label="Clear" icon={<ClearOutlined />} disabled={!hasInput && !hasResult} onClick={onClear}>
               {!isMobile && "Clear"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Copy repaired JSON to clipboard">
-            <Button icon={<CopyOutlined />} disabled={!hasResult} onClick={onCopy}>
+            <Button aria-label="Copy" icon={<CopyOutlined />} disabled={!hasResult} onClick={onCopy}>
               {!isMobile && "Copy"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Save repaired JSON to file">
-            <Button icon={<DownloadOutlined />} disabled={!hasResult} onClick={onSaveAs}>
+            <Button aria-label="Save As…" icon={<DownloadOutlined />} disabled={!hasResult} onClick={onSaveAs}>
               {isMobile ? "Save" : "Save As…"}
             </Button>
           </Tooltip>

--- a/src/screens/jwt-decoder/jwt-decoder-toolbar.tsx
+++ b/src/screens/jwt-decoder/jwt-decoder-toolbar.tsx
@@ -85,21 +85,23 @@ export const JwtDecoderToolbar = ({ hasToken, decoded, onLoadSample, onClear }: 
       leading={
         <Space size="small" wrap>
           <Dropdown menu={{ items: sampleMenuItems }} placement="bottomLeft">
-            <Button icon={<FileTextOutlined />}>{!isMobile && "Load Sample"}</Button>
+            <Button aria-label="Load Sample" icon={<FileTextOutlined />}>
+              {!isMobile && "Load Sample"}
+            </Button>
           </Dropdown>
         </Space>
       }
       actions={
         <Space size="small" wrap>
           <Tooltip title="Clear token">
-            <Button icon={<ClearOutlined />} disabled={!hasToken} onClick={onClear}>
+            <Button aria-label="Clear" icon={<ClearOutlined />} disabled={!hasToken} onClick={onClear}>
               {!isMobile && "Clear"}
             </Button>
           </Tooltip>
 
           <Dropdown menu={{ items: copyMenuItems }} placement="bottomRight" disabled={!decoded.isValid}>
             <Tooltip title="Copy decoded JWT">
-              <Button icon={<CopyOutlined />} disabled={!decoded.isValid}>
+              <Button aria-label="Copy" icon={<CopyOutlined />} disabled={!decoded.isValid}>
                 {!isMobile && "Copy"}
               </Button>
             </Tooltip>

--- a/src/screens/poker-planning/components/poker-planning-toolbar.tsx
+++ b/src/screens/poker-planning/components/poker-planning-toolbar.tsx
@@ -39,6 +39,7 @@ export const PokerPlanningToolbar = ({ isUserMemberOfRoom, onClearVotes }: Poker
           <Tooltip title="Create a new room and start the session">
             <Button
               type="primary"
+              aria-label="New Room"
               icon={<PlusOutlined />}
               disabled={!canCreateRoom || isConnecting}
               loading={isConnecting}
@@ -49,13 +50,13 @@ export const PokerPlanningToolbar = ({ isUserMemberOfRoom, onClearVotes }: Poker
           </Tooltip>
 
           <Tooltip title="Join the current room">
-            <Button icon={<TeamOutlined />} disabled={!canJoin} onClick={joinRoom}>
+            <Button aria-label="Join" icon={<TeamOutlined />} disabled={!canJoin} onClick={joinRoom}>
               {!isMobile && "Join"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Copy room link to clipboard">
-            <Button icon={<CopyOutlined />} disabled={!canShareLink} onClick={handleCopyLink}>
+            <Button aria-label="Copy Link" icon={<CopyOutlined />} disabled={!canShareLink} onClick={handleCopyLink}>
               {!isMobile && "Copy Link"}
             </Button>
           </Tooltip>
@@ -64,14 +65,20 @@ export const PokerPlanningToolbar = ({ isUserMemberOfRoom, onClearVotes }: Poker
       actions={
         <Space size="small" wrap>
           <Tooltip title="Clear all votes">
-            <Button icon={<ClearOutlined />} danger disabled={!isUserMemberOfRoom} onClick={onClearVotes}>
+            <Button
+              aria-label="Clear Votes"
+              icon={<ClearOutlined />}
+              danger
+              disabled={!isUserMemberOfRoom}
+              onClick={onClearVotes}
+            >
               {!isMobile && "Clear Votes"}
             </Button>
           </Tooltip>
 
           {isConnected ? (
             <Tooltip title="Disconnect from the room">
-              <Button icon={<DisconnectOutlined />} onClick={disconnect}>
+              <Button aria-label="Disconnect" icon={<DisconnectOutlined />} onClick={disconnect}>
                 {!isMobile && "Disconnect"}
               </Button>
             </Tooltip>

--- a/src/screens/qrcode/decoder/qrcode-decoder-toolbar.tsx
+++ b/src/screens/qrcode/decoder/qrcode-decoder-toolbar.tsx
@@ -28,13 +28,13 @@ export const QRCodeDecoderToolbar = ({
       actions={
         <Space size="small" wrap>
           <Tooltip title="Clear image and result">
-            <Button icon={<ClearOutlined />} disabled={!hasImage && !hasResult} onClick={onClear}>
+            <Button aria-label="Clear" icon={<ClearOutlined />} disabled={!hasImage && !hasResult} onClick={onClear}>
               {!isMobile && "Clear"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Copy decoded text to clipboard">
-            <Button icon={<CopyOutlined />} disabled={!hasResult} onClick={onCopyResult}>
+            <Button aria-label="Copy Result" icon={<CopyOutlined />} disabled={!hasResult} onClick={onCopyResult}>
               {!isMobile && "Copy Result"}
             </Button>
           </Tooltip>

--- a/src/screens/qrcode/generator/qrcode-generator-toolbar.tsx
+++ b/src/screens/qrcode/generator/qrcode-generator-toolbar.tsx
@@ -32,25 +32,25 @@ export const QRCodeGeneratorToolbar = ({
       actions={
         <Space size="small" wrap>
           <Tooltip title="Clear all fields">
-            <Button icon={<ClearOutlined />} disabled={!hasContent && !hasResult} onClick={onClear}>
+            <Button aria-label="Clear" icon={<ClearOutlined />} disabled={!hasContent && !hasResult} onClick={onClear}>
               {!isMobile && "Clear"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Copy QR code data URL to clipboard">
-            <Button icon={<CopyOutlined />} disabled={!hasResult} onClick={onCopyDataUrl}>
+            <Button aria-label="Copy URL" icon={<CopyOutlined />} disabled={!hasResult} onClick={onCopyDataUrl}>
               {!isMobile && "Copy URL"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Copy QR code image to clipboard">
-            <Button icon={<PictureOutlined />} disabled={!hasResult} onClick={onCopyImage}>
+            <Button aria-label="Copy Image" icon={<PictureOutlined />} disabled={!hasResult} onClick={onCopyImage}>
               {!isMobile && "Copy Image"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Download QR code image">
-            <Button icon={<DownloadOutlined />} disabled={!hasResult} onClick={onDownload}>
+            <Button aria-label="Download" icon={<DownloadOutlined />} disabled={!hasResult} onClick={onDownload}>
               {!isMobile && "Download"}
             </Button>
           </Tooltip>

--- a/src/screens/regex-tester/regex-tester-toolbar.tsx
+++ b/src/screens/regex-tester/regex-tester-toolbar.tsx
@@ -43,19 +43,30 @@ export const RegexTesterToolbar = () => {
       actions={
         <Space size="small" wrap>
           <Tooltip title="Clear all fields">
-            <Button icon={<ClearOutlined />} disabled={!hasPattern} onClick={clearAll}>
+            <Button aria-label="Clear" icon={<ClearOutlined />} disabled={!hasPattern} onClick={clearAll}>
               {!isMobile && "Clear"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Copy regex pattern">
-            <Button icon={<CopyOutlined />} disabled={!hasPattern} onClick={handleCopyPattern}>
+            <Button
+              aria-label="Copy Pattern"
+              icon={<CopyOutlined />}
+              disabled={!hasPattern}
+              onClick={handleCopyPattern}
+            >
               {!isMobile && "Copy Pattern"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Copy extracted values">
-            <Button type="primary" icon={<CopyOutlined />} disabled={!hasExtracted} onClick={handleCopyExtracted}>
+            <Button
+              type="primary"
+              aria-label="Copy Extracted"
+              icon={<CopyOutlined />}
+              disabled={!hasExtracted}
+              onClick={handleCopyExtracted}
+            >
               {!isMobile && "Copy Extracted"}
             </Button>
           </Tooltip>

--- a/src/screens/url/curl/url-curl.tsx
+++ b/src/screens/url/curl/url-curl.tsx
@@ -92,12 +92,18 @@ export const UrlCurl = () => {
           actions={
             <Space size="small" wrap>
               <Tooltip title="Copy result to clipboard">
-                <Button icon={<CopyOutlined />} disabled={!transformedResult} onClick={handleCopy}>
+                <Button aria-label="Copy" icon={<CopyOutlined />} disabled={!transformedResult} onClick={handleCopy}>
                   {!isMobile && "Copy"}
                 </Button>
               </Tooltip>
 
-              <Button type="primary" icon={<CodeOutlined />} disabled={isBlank(inputCurl)} onClick={handleConvert}>
+              <Button
+                type="primary"
+                aria-label="Convert"
+                icon={<CodeOutlined />}
+                disabled={isBlank(inputCurl)}
+                onClick={handleConvert}
+              >
                 {isMobile ? "Conv." : "Convert"}
               </Button>
             </Space>

--- a/src/screens/uuid-generator/uuid-generator-toolbar.tsx
+++ b/src/screens/uuid-generator/uuid-generator-toolbar.tsx
@@ -27,13 +27,13 @@ export const UuidGeneratorToolbar = ({ hasResult, onGenerate, onClear }: UuidGen
       actions={
         <Space size="small" wrap>
           <Tooltip title="Clear generated UUIDs">
-            <Button icon={<ClearOutlined />} disabled={!hasResult} onClick={onClear}>
+            <Button aria-label="Clear" icon={<ClearOutlined />} disabled={!hasResult} onClick={onClear}>
               {!isMobile && "Clear"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Copy UUIDs to clipboard">
-            <Button icon={<CopyOutlined />} disabled={!hasResult} onClick={handleCopy}>
+            <Button aria-label="Copy" icon={<CopyOutlined />} disabled={!hasResult} onClick={handleCopy}>
               {!isMobile && "Copy"}
             </Button>
           </Tooltip>

--- a/src/screens/vr-3d-viewer/vr-3d-viewer-toolbar.tsx
+++ b/src/screens/vr-3d-viewer/vr-3d-viewer-toolbar.tsx
@@ -30,25 +30,40 @@ export const Vr3dViewerToolbar = ({
       actions={
         <Space size="small" wrap>
           <Tooltip title="Toggle settings panel">
-            <Button icon={<SettingOutlined />} type={showSettings ? "primary" : "default"} onClick={onToggleSettings}>
+            <Button
+              aria-label="Settings"
+              icon={<SettingOutlined />}
+              type={showSettings ? "primary" : "default"}
+              onClick={onToggleSettings}
+            >
               {!isMobile && "Settings"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Reset camera view">
-            <Button icon={<ReloadOutlined />} disabled={!hasModel || isLoading} onClick={onResetCamera}>
+            <Button
+              aria-label="Reset View"
+              icon={<ReloadOutlined />}
+              disabled={!hasModel || isLoading}
+              onClick={onResetCamera}
+            >
               {!isMobile && "Reset View"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Toggle fullscreen">
-            <Button icon={<ExpandOutlined />} disabled={!hasModel || isLoading} onClick={onFullscreen}>
+            <Button
+              aria-label="Fullscreen"
+              icon={<ExpandOutlined />}
+              disabled={!hasModel || isLoading}
+              onClick={onFullscreen}
+            >
               {!isMobile && "Fullscreen"}
             </Button>
           </Tooltip>
 
           <Tooltip title="Clear current model">
-            <Button icon={<ClearOutlined />} disabled={!hasModel || isLoading} onClick={onClear}>
+            <Button aria-label="Clear" icon={<ClearOutlined />} disabled={!hasModel || isLoading} onClick={onClear}>
               {!isMobile && "Clear"}
             </Button>
           </Tooltip>


### PR DESCRIPTION
## Changes Description

- **E2E Tests:** add mobile and tablet Playwright projects and support narrow-viewport tab interactions.
  - New `mobile-chrome` (Pixel 7) and `tablet` (768x1024, touch) Playwright projects, plus `test:e2e:responsive` / `test:e2e:all` npm scripts.
  - Added `clickTab` helper (scroll-into-view + force click) for overflowed AntD tabs on narrow viewports, used in common-lists and date-converter specs.
- **Responsive UI:** fix latent bugs exposed by the new narrow viewports.
  - Icon-only toolbar buttons now expose `aria-label`s and disable hover-triggered tooltips on mobile, across ~20 toolbar components.
  - AntD tabs wrap instead of overflowing/clipping on screens ≤576px (`app-layout-tabs.tsx`).
  - Date-converter mobile result layout simplified; minor responsive tweaks to GitHub filter/search rows and HTML entities columns.
- **Docs:** README badges/scripts refresh and new habit-hooks guide for non-essential comments.

## Checklist

- [ ] code follows project [coding guidelines](https://github.com/amwebexpert/chrome-extensions-collection/blob/master/packages/coding-guide-helper/public/markdowns/table-of-content.md).
- [x] documentation has been updated (if applicable).
- [x] tests have been added or updated (if applicable).
- [x] e2e tests completed

## Screen capture(s) or recording

<img width="2032" height="1005" alt="image" src="https://github.com/user-attachments/assets/8df87625-3576-4f88-a492-dc71889f427e" />

