### PR TITLE
fix(ci): skip habit-hooks in pre-commit on CI

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -11,6 +11,10 @@ echo "Running lint-staged to apply automatic fixes to staged files…"
 bunx lint-staged
 echo "✅ Lint staged completed"
 
-echo "Running habit-hooks to catches structural smells…"
-bun run habit:hooks
-echo "✅ Habit Hooks completed"
+if [ -n "$CI" ]; then
+  echo "⏭️  CI detected — skipping habit-hooks (not required for CI lint:ci)"
+else
+  echo "Running habit-hooks to catches structural smells…"
+  bun run habit:hooks
+  echo "✅ Habit Hooks completed"
+fi


### PR DESCRIPTION
Release workflow commits were failing because husky ran habit:hooks without the uv-installed binary; CI already gates on lint:ci instead.

## Changes Description

- skip habit-hooks in pre-commit on CI

## Checklist

- [ ] code follows project [coding guidelines](https://github.com/amwebexpert/chrome-extensions-collection/blob/master/packages/coding-guide-helper/public/markdowns/table-of-content.md).
- [ ] documentation has been updated (if applicable).
- [ ] tests have been added or updated (if applicable).
- [ ] e2e tests completed

## Screen capture(s) or recording

- 🚫
